### PR TITLE
fix: display the excerpt list of vendors and products in CVEs listing

### DIFF
--- a/opencve/context.py
+++ b/opencve/context.py
@@ -84,36 +84,42 @@ def _humanize_filter(s):
 
 
 def _excerpt(objects, _type):
+    """
+    This function takes a flat list of vendors and products and returns
+    the HTML code used in the CVEs list page.
+    """
     output = ""
 
     if not objects:
         return output
 
-    if len(objects) > app.config["COUNT_EXCERPT"]:
-        objects = objects[: app.config["COUNT_EXCERPT"]]
-
-    # Returns products or vendors
+    # Keep the objects of the requested type
     if _type == "products":
         objects = [o for o in objects if PRODUCT_SEPARATOR in o]
     else:
         objects = [o for o in objects if not PRODUCT_SEPARATOR in o]
 
+    objects = sorted(objects)
     output += '<span class="badge badge-primary">{}</span> '.format(len(objects))
-    ordered = sorted(objects)
 
+    # Keep the remains size and reduce the list
+    remains = len(objects[app.config["COUNT_EXCERPT"] :])
+
+    if len(objects) > app.config["COUNT_EXCERPT"]:
+        objects = objects[: app.config["COUNT_EXCERPT"]]
+
+    # Construct the HTML
     for idx, obj in enumerate(objects):
-        try:
-            # Products are formed like vendorPRODUCT_SEPARATORproduct
+        if _type == "products":
             vendor, product = obj.split(PRODUCT_SEPARATOR)
             url = url_for("main.cves", vendor=vendor, product=product)
             output += f"<a href='{url}'>{_humanize_filter(product)}</a>"
-        except ValueError:
+        else:
             url = url_for("main.cves", vendor=obj)
             output += f"<a href='{url}'>{_humanize_filter(obj)}</a>"
 
         output += ", " if idx + 1 != len(objects) else " "
 
-    remains = len(ordered[app.config["COUNT_EXCERPT"] :])
     if remains:
         output += "<i>and {} more</i>".format(remains)
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,88 @@
+from opencve.constants import PRODUCT_SEPARATOR
+from opencve.context import _excerpt
+
+
+def test_vendors_excerpt_without_more():
+    result = _excerpt(
+        [
+            "vendor1",
+            "vendor2",
+            f"vendor1{PRODUCT_SEPARATOR}product1",
+            f"vendor2{PRODUCT_SEPARATOR}product2",
+        ],
+        "vendors",
+    )
+
+    assert '<span class="badge badge-primary">2</span>' in result
+    assert "Vendor1" in result
+    assert "cve?vendor=vendor1" in result
+    assert "Vendor2" in result
+    assert "cve?vendor=vendor2" in result
+
+
+def test_vendors_excerpt_with_more():
+    result = _excerpt(
+        [
+            "vendor1",
+            "vendor2",
+            "vendor3",
+            "vendor4",
+            f"vendor1{PRODUCT_SEPARATOR}product1",
+            f"vendor2{PRODUCT_SEPARATOR}product2",
+            f"vendor3{PRODUCT_SEPARATOR}product3",
+            f"vendor4{PRODUCT_SEPARATOR}product4",
+        ],
+        "vendors",
+    )
+
+    assert '<span class="badge badge-primary">4</span>' in result
+    assert "Vendor1" in result
+    assert "cve?vendor=vendor1" in result
+    assert "Vendor2" in result
+    assert "cve?vendor=vendor2" in result
+    assert "Vendor3" in result
+    assert "cve?vendor=vendor3" in result
+    assert "<i>and 1 more</i>" in result
+
+
+def test_products_excerpt_without_more():
+    result = _excerpt(
+        [
+            "vendor1",
+            "vendor2",
+            f"vendor1{PRODUCT_SEPARATOR}product1",
+            f"vendor2{PRODUCT_SEPARATOR}product2",
+        ],
+        "products",
+    )
+
+    assert '<span class="badge badge-primary">2</span>' in result
+    assert "Product1" in result
+    assert "cve?vendor=vendor1&product=product1" in result
+    assert "Product2" in result
+    assert "cve?vendor=vendor2&product=product2" in result
+
+
+def test_products_excerpt_with_more():
+    result = _excerpt(
+        [
+            "vendor1",
+            "vendor2",
+            "vendor3",
+            "vendor4",
+            f"vendor1{PRODUCT_SEPARATOR}product1",
+            f"vendor2{PRODUCT_SEPARATOR}product2",
+            f"vendor3{PRODUCT_SEPARATOR}product3",
+            f"vendor4{PRODUCT_SEPARATOR}product4",
+        ],
+        "products",
+    )
+
+    assert '<span class="badge badge-primary">4</span>' in result
+    assert "Product1" in result
+    assert "cve?vendor=vendor1&product=product1" in result
+    assert "Product2" in result
+    assert "cve?vendor=vendor2&product=product2" in result
+    assert "Product3" in result
+    assert "cve?vendor=vendor3&product=product3" in result
+    assert "<i>and 1 more</i>" in result


### PR DESCRIPTION
![pr_opencve_excerpt](https://user-images.githubusercontent.com/1552526/103463067-f12a2100-4d29-11eb-9b21-92e6ca4c2528.png)
