### PR TITLE
fix: check if email is unique when editing a profile

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ os.environ["OPENCVE_WELCOME_FILES"] = str(
 
 import pytest
 from bs4 import BeautifulSoup
+from flask import url_for
 
 from opencve import create_app
 from opencve.commands.utils import CveUtil
@@ -151,3 +152,17 @@ def get_cve_names():
         ]
 
     return _get_cve_names
+
+
+@pytest.fixture(scope="function")
+def login(create_user, client):
+    create_user()
+    client.post(
+        url_for("user.login"),
+        data={"username": "user", "password": "password"},
+        follow_redirects=True,
+    )
+
+    yield
+
+    client.post(url_for("user.logout"), follow_redirects=True)

--- a/tests/controllers/test_profile.py
+++ b/tests/controllers/test_profile.py
@@ -1,0 +1,55 @@
+import pytest
+from flask import request
+
+from opencve.models.users import User
+
+
+@pytest.mark.parametrize(
+    "first_name,last_name,email",
+    [
+        ("john", "doe", "john.doe@example.com"),
+        ("john", "", "john.doe@example.com"),
+        ("", "doe", "john.doe@example.com"),
+        ("", "", "john.doe@example.com"),
+        ("", "", "user@opencve.io"),
+    ],
+)
+def test_edit_profile(login, client, first_name, last_name, email):
+    user = User.query.first()
+    assert user.first_name == ""
+    assert user.last_name == ""
+    assert user.email == "user@opencve.io"
+
+    client.post(
+        "/account/profile",
+        data={"first_name": first_name, "last_name": last_name, "email": email},
+        follow_redirects=True,
+    )
+
+    user = User.query.first()
+    assert user.first_name == first_name
+    assert user.last_name == last_name
+    assert user.email == email
+
+
+def test_edit_profile_email_required(login, client):
+    response = client.post(
+        "/account/profile", data={"email": ""}, follow_redirects=True
+    )
+    assert b"This field is required." in response.data
+
+
+def test_edit_profile_with_existing_email(login, create_user, client):
+    user = User.query.filter_by(username="user").first()
+    assert user.email == "user@opencve.io"
+
+    create_user("user2")
+
+    response = client.post(
+        "/account/profile", data={"email": "user2@opencve.io"}, follow_redirects=True
+    )
+    assert b"This Email is already in use. Please try another one" in response.data
+
+    # Email has not changed
+    user = User.query.filter_by(username="user").first()
+    assert user.email == "user@opencve.io"


### PR DESCRIPTION
The unicity of emails was not checked when the user tried to update his own email in his profile.

This PR also removes the first and last names requirements. It was not practical : if the user wanted to modify his email, the first and last names were required, even if we don't display it anywhere.