### PR TITLE
#76 : fix "stmp_password" in configuration

### DIFF
--- a/opencve/default.cfg
+++ b/opencve/default.cfg
@@ -48,4 +48,4 @@ smtp_server = smtp.example.com
 smtp_port = 465
 smtp_use_tls = True
 smtp_username = username
-stmp_password = password
+smtp_password = password

--- a/opencve/settings.py
+++ b/opencve/settings.py
@@ -113,7 +113,13 @@ class Config(object):
     MAIL_PORT = config.getint("mail", "smtp_port", fallback=465)
     MAIL_USE_TLS = config.getboolean("mail", "smtp_use_tls", fallback=True)
     MAIL_USERNAME = config.get("mail", "smtp_username")
-    MAIL_PASSWORD = config.get("mail", "stmp_password")
+
+    # ensure compatibility before deprecating "stmp_password"
+    # see https://github.com/opencve/opencve/issues/76
+    try:
+        MAIL_PASSWORD = config.get("mail", "smtp_password")
+    except:
+        MAIL_PASSWORD = config.get("mail", "stmp_password")
 
     DEFAULT_MAIL_SENDER = config.get(
         "mail", "email_from", fallback="no-reply@opencve.io"

--- a/tests/opencve.cfg
+++ b/tests/opencve.cfg
@@ -48,4 +48,4 @@ smtp_server = smtp.example.com
 smtp_port = 465
 smtp_use_tls = True
 smtp_username = username
-stmp_password = password
+smtp_password = password


### PR DESCRIPTION
Like we discussed in issue #76, this fix aims to ensure compatibility with old `stmp_password` option.