### PR TITLE
chore: pin pallets dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,11 @@ nested-lookup==0.2.18
 deepdiff==4.0.7
 gunicorn==20.0.4
 vine==1.3.0
+click==7.1.2
+werkzeug==1.0.1
+itsdangerous==1.1.0
+markupSafe==1.1.1
+jinja2==2.11.3
 
 # Required by WTForms (new bug?)
 # see: https://stackoverflow.com/questions/61356834/wtforms-install-email-validator-for-email-validation-support


### PR DESCRIPTION
The Pallets Project has upgraded their main projects to major versions : https://palletsprojects.com/blog/flask-2-0-released/

OpenCVE pinned Flask but not its own dependencies, including Click, Werkzeug, ItsDangerous, MarkupSafe and Jinja2. The consequence is that the tests no longer passed (https://github.com/opencve/opencve/runs/2578789549?check_suite_focus=true).

This PR pins these dependencies, so we're sure OpenCVE will still work. Note that a future work has to be done to upgrade these package (ie support Flask 2.0).