### PR TITLE
bugfix: trim() the text of the 'Subscribe' button

### DIFF
--- a/opencve/static/js/custom.js
+++ b/opencve/static/js/custom.js
@@ -29,7 +29,7 @@ $.ajaxSetup({
                 if ( data.status == 'ok' ) {
                     $(button).toggleClass('btn-default btn-danger');
 
-                    if ( $(button).text() == 'Subscribe' ) {
+                    if ( $(button).text().trim() == 'Subscribe' ) {
                         $(button).text('Unsubscribe');
                         $(button).attr("id", $(button).attr('id').replace('subscribe', 'unsubscribe'));
                     } else {


### PR DESCRIPTION
When user clicks the "Subscribe" button at the first time,  $(button).text() gets return value "Subscribe    \n" instead of "Subscribe", which makes the callback function works incorrectly.