### PR TITLE
fix: improve error messages in create-user command

### DIFF
--- a/opencve/commands/create_user.py
+++ b/opencve/commands/create_user.py
@@ -19,6 +19,11 @@ from opencve.models.users import User
 @with_appcontext
 def create_user(username, email, password, admin):
     """Create a user or admin."""
+    if User.query.filter_by(username=username).first():
+        raise click.BadParameter(f"{username} already exists.", param_hint="username")
+    if User.query.filter_by(email=email).first():
+        raise click.BadParameter(f"{email} already exists.", param_hint="email")
+
     user = User(
         username=username,
         email=email,

--- a/tests/commands/test_create_user.py
+++ b/tests/commands/test_create_user.py
@@ -52,3 +52,28 @@ def test_create_admin(app):
     assert user.username == "john"
     assert user.email == "john@domain.com"
     assert user.admin
+
+
+def test_create_user_already_exists(app):
+    runner = app.test_cli_runner()
+
+    result = runner.invoke(
+        create_user, ["john", "john@domain.com"], input="password\npassword\n"
+    )
+    assert result.exit_code == 0
+    assert "[*] User john created." in result.output
+
+    result = runner.invoke(
+        create_user, ["john", "john@domain.com"], input="password\npassword\n"
+    )
+    assert result.exit_code == 2
+    assert "Error: Invalid value for username: john already exists." in result.output
+
+    result = runner.invoke(
+        create_user, ["john2", "john@domain.com"], input="password\npassword\n"
+    )
+    assert result.exit_code == 2
+    assert (
+        "Error: Invalid value for email: john@domain.com already exists."
+        in result.output
+    )


### PR DESCRIPTION
The `create-user` command now uses the builtin `click.BadParameter` exception:

```
$ opencve create-user john3 john3@email.fr
Password:
Repeat for confirmation:
Usage: opencve create-user [OPTIONS] USERNAME EMAIL

Error: Invalid value for username: john3 already exists.
```