### PR TITLE
fix: Subscribe to invalid ID throws 400 instead of 500 error.

### DIFF
--- a/opencve/controllers/subscriptions.py
+++ b/opencve/controllers/subscriptions.py
@@ -67,13 +67,9 @@ def subscribe_to_tag():
     elif request.form["obj"] == "product":
         if not is_valid_uuid(request.form["id"]):
             return _bad_request(request.form["obj"], request.form["id"])
-        else:
-            try:
-                product = Product.query.get(request.form["id"])
-                if product is None:
-                    return _bad_request(request.form["obj"], request.form["id"])
-            except HTTPException:
-                return _bad_request(request.form["obj"], request.form["id"])
+        product = Product.query.get(request.form["id"])
+        if not product:
+            return _bad_request(request.form["obj"], request.form["id"])
 
         # Subscribe
         if request.form["action"] == "subscribe":

--- a/opencve/controllers/subscriptions.py
+++ b/opencve/controllers/subscriptions.py
@@ -10,6 +10,8 @@ from opencve.models.products import Product
 from opencve.models.vendors import Vendor
 from opencve.models import is_valid_uuid
 
+from werkzeug.exceptions import HTTPException
+
 
 @main.route("/subscriptions", methods=["POST"])
 @login_required
@@ -35,12 +37,15 @@ def subscribe_to_tag():
 
     # Vendor
     if request.form["obj"] == "vendor":
-        if (
-            not is_valid_uuid(request.form["id"])
-            or str(Vendor.query.get(request.form["id"])) == "None"
-        ):
+        if not is_valid_uuid(request.form["id"]):
             return _bad_request(request.form["obj"], request.form["id"])
-        vendor = VendorController.get({"id": request.form["id"]})
+        else:
+            try:
+                vendor = Vendor.query.get(request.form["id"])
+                if vendor is None:
+                    return _bad_request(request.form["obj"], request.form["id"])
+            except HTTPException:
+                return _bad_request(request.form["obj"], request.form["id"])
 
         # Subscribe
         if request.form["action"] == "subscribe":
@@ -60,12 +65,15 @@ def subscribe_to_tag():
 
     # Product
     elif request.form["obj"] == "product":
-        if (
-            not is_valid_uuid(request.form["id"])
-            or str(Product.query.get(request.form["id"])) == "None"
-        ):
+        if not is_valid_uuid(request.form["id"]):
             return _bad_request(request.form["obj"], request.form["id"])
-        product = Product.query.get(request.form["id"])
+        else:
+            try:
+                product = Product.query.get(request.form["id"])
+                if product is None:
+                    return _bad_request(request.form["obj"], request.form["id"])
+            except HTTPException:
+                return _bad_request(request.form["obj"], request.form["id"])
 
         # Subscribe
         if request.form["action"] == "subscribe":

--- a/opencve/controllers/subscriptions.py
+++ b/opencve/controllers/subscriptions.py
@@ -39,13 +39,9 @@ def subscribe_to_tag():
     if request.form["obj"] == "vendor":
         if not is_valid_uuid(request.form["id"]):
             return _bad_request(request.form["obj"], request.form["id"])
-        else:
-            try:
-                vendor = Vendor.query.get(request.form["id"])
-                if vendor is None:
-                    return _bad_request(request.form["obj"], request.form["id"])
-            except HTTPException:
-                return _bad_request(request.form["obj"], request.form["id"])
+        vendor = Vendor.query.get(request.form["id"])
+        if not vendor:
+            return _bad_request(request.form["obj"], request.form["id"])
 
         # Subscribe
         if request.form["action"] == "subscribe":

--- a/opencve/controllers/subscriptions.py
+++ b/opencve/controllers/subscriptions.py
@@ -1,17 +1,25 @@
 import json
 
-from flask import request
+from flask import request, jsonify
 from flask_user import current_user, login_required
 
 from opencve.controllers.main import main
 from opencve.extensions import db
+from opencve.controllers.vendors import VendorController
 from opencve.models.products import Product
 from opencve.models.vendors import Vendor
+from opencve.models import is_valid_uuid
 
 
 @main.route("/subscriptions", methods=["POST"])
 @login_required
 def subscribe_to_tag():
+    def _bad_request(type, id):
+        return (
+            jsonify({"status": "error", "message": f"{type} {id} does not exist"}),
+            400,
+        )
+
     if not current_user.is_authenticated:
         return json.dumps({"status": "error", "message": "not allowed"})
 
@@ -27,7 +35,12 @@ def subscribe_to_tag():
 
     # Vendor
     if request.form["obj"] == "vendor":
-        vendor = Vendor.query.get(request.form["id"])
+        if (
+            not is_valid_uuid(request.form["id"])
+            or str(Vendor.query.get(request.form["id"])) == "None"
+        ):
+            return _bad_request(request.form["obj"], request.form["id"])
+        vendor = VendorController.get({"id": request.form["id"]})
 
         # Subscribe
         if request.form["action"] == "subscribe":
@@ -47,6 +60,11 @@ def subscribe_to_tag():
 
     # Product
     elif request.form["obj"] == "product":
+        if (
+            not is_valid_uuid(request.form["id"])
+            or str(Product.query.get(request.form["id"])) == "None"
+        ):
+            return _bad_request(request.form["obj"], request.form["id"])
         product = Product.query.get(request.form["id"])
 
         # Subscribe

--- a/opencve/controllers/subscriptions.py
+++ b/opencve/controllers/subscriptions.py
@@ -5,7 +5,6 @@ from flask_user import current_user, login_required
 
 from opencve.controllers.main import main
 from opencve.extensions import db
-from opencve.controllers.vendors import VendorController
 from opencve.models.products import Product
 from opencve.models.vendors import Vendor
 from opencve.models import is_valid_uuid

--- a/tests/controllers/test_subscriptions.py
+++ b/tests/controllers/test_subscriptions.py
@@ -116,3 +116,39 @@ def test_unsubscribe_to_product_subscribed_to(login, client, create_vendor):
         assert response.status_code == 200
         assert b'"message": "product removed"' in response.data
         assert b'"status": "ok"' in response.data
+
+
+def test_subscribe_to_invalid_vendor_id(login, client):
+
+    with client:
+        response = client.post(
+            "/subscriptions",
+            data={
+                "obj": "vendor",
+                "id": "invalid_id",
+                "action": "subscribe",
+            },
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 400
+        assert b'"message":"vendor invalid_id does not exist"' in response.data
+        assert b'"status":"error"' in response.data
+
+
+def test_subscribe_to_invalid_product_id(login, client):
+
+    with client:
+        response = client.post(
+            "/subscriptions",
+            data={
+                "obj": "product",
+                "id": "invalid_id",
+                "action": "subscribe",
+            },
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 400
+        assert b'"message":"product invalid_id does not exist"' in response.data
+        assert b'"status":"error"' in response.data

--- a/tests/controllers/test_subscriptions.py
+++ b/tests/controllers/test_subscriptions.py
@@ -118,7 +118,7 @@ def test_unsubscribe_to_product_subscribed_to(login, client, create_vendor):
         assert b'"status": "ok"' in response.data
 
 
-def test_subscribe_to_invalid_vendor_id(login, client):
+def test_subscribe_to_invalid_vendor_id_with_invalid_uuid(login, client):
 
     with client:
         response = client.post(
@@ -132,11 +132,11 @@ def test_subscribe_to_invalid_vendor_id(login, client):
         )
 
         assert response.status_code == 400
-        assert b'"message":"vendor invalid_id does not exist"' in response.data
-        assert b'"status":"error"' in response.data
+        assert response.json["message"] == "vendor invalid_id does not exist"
+        assert response.json["status"] == "error"
 
 
-def test_subscribe_to_invalid_product_id(login, client):
+def test_subscribe_to_invalid_product_id_with_invalid_uuid(login, client):
 
     with client:
         response = client.post(
@@ -150,5 +150,47 @@ def test_subscribe_to_invalid_product_id(login, client):
         )
 
         assert response.status_code == 400
-        assert b'"message":"product invalid_id does not exist"' in response.data
-        assert b'"status":"error"' in response.data
+        assert response.json["message"] == "product invalid_id does not exist"
+        assert response.json["status"] == "error"
+
+
+def test_subscribe_to_invalid_vendor_id_with_valid_uuid(login, client):
+
+    with client:
+        response = client.post(
+            "/subscriptions",
+            data={
+                "obj": "vendor",
+                "id": "38e0697e-b406-4724-80af-e39e354b291c",
+                "action": "subscribe",
+            },
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 400
+        assert (
+            response.json["message"]
+            == "vendor 38e0697e-b406-4724-80af-e39e354b291c does not exist"
+        )
+        assert response.json["status"] == "error"
+
+
+def test_subscribe_to_invalid_product_id_with_valid_uuid(login, client):
+
+    with client:
+        response = client.post(
+            "/subscriptions",
+            data={
+                "obj": "product",
+                "id": "38e0697e-b406-4724-80af-e39e354b291c",
+                "action": "subscribe",
+            },
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 400
+        assert (
+            response.json["message"]
+            == "product 38e0697e-b406-4724-80af-e39e354b291c does not exist"
+        )
+        assert response.json["status"] == "error"


### PR DESCRIPTION
In reference to #121 :
This change to the subscriptions controller verifies that the id being passed into the subscriptions POST request is not an invalid ID. It does this by first checking if the ID is passed in is a valid uuid, but then also verifies that it exists within the database if it is a valid uuid. If there is any problem with the id that is passed in, a 400 error is thrown and a JSON response is sent that the id does not exist.