### PR TITLE
Dev/ncrocfer/fix latency homepage

### DIFF
--- a/opencve/controllers/home.py
+++ b/opencve/controllers/home.py
@@ -43,7 +43,9 @@ def home():
 
     objects = []
     pagination = None
-    reports = ReportController.list_items({"user_id": current_user.id})
+
+    # Only display the 5 last reports
+    reports = ReportController.list_items({"user_id": current_user.id})[:5]
 
     # If user has subscriptions we can display the last activities of the vendors
     if vendors:

--- a/opencve/templates/home.html
+++ b/opencve/templates/home.html
@@ -199,15 +199,13 @@
                     <table class="table">
                         <thead>
                         <tr><th class="col-md-2">Date</th>
-                        <th class="col-md-1 text-center">Alerts</th>
                         <th>Vendors &amp; Products</th>
                         </tr></thead>
 
                         <tbody>
                         {% for report in reports %}
                         <tr>
-                            <td><a href="{{ url_for('main.report', link=report.public_link) }}">04/01/21</a></td>
-                            <td class="text-center">{{ report.alerts|length }}</td>
+                            <td><a href="{{ url_for('main.report', link=report.public_link) }}">{{ report.created_at.strftime("%d/%m/%y") }}</a></td>
                             <td>{{ report.details|report_excerpt|safe }}</td>
                         </tr>
                         {% endfor %}


### PR DESCRIPTION
The number of reports was too large, no need to display as much items.

We also remove the number of alerts in the report table (too many join, each SQL request was about 500ms...). The problem is the same on the `/reports` page, but the new integrations feature coming in the next week will change the report behaviour, so no need to fix that too now :)

![opencve_alerts_latency](https://user-images.githubusercontent.com/1552526/129111651-860230a5-ebbc-42e7-a8d7-630987be63e3.png)
