### PR TITLE
fix: sort the activities in homepage and increase performance of SQL query

### DIFF
--- a/opencve/templates/home.html
+++ b/opencve/templates/home.html
@@ -14,20 +14,20 @@
 <section class="content">
     <div class="row">
         <div class="col-md-8">
-            {% if not changes.items %}
+            {% if not changes %}
             <p class="alert alert-info">
                 {% if not current_user.vendors and not current_user.products %}
                 You have to subscribe to <a href="{{ url_for('main.vendors') }}">products and vendors</a> to see their last changes.
                 {% else %}
-                Your subscriptions haven't changed yet.
+                No changes available.
                 {% endif %}
             </p>
             {% else %}
                 <ul class="timeline">
 
                     {% set ns = namespace(last_day=false) %}
-                    {% for change in changes.items %}
-                    {% set ns.current_day = change.created_at.strftime("%A, %B %d") %}
+                    {% for change in changes %}
+                    {% set ns.current_day = change.created_at.strftime("%d %b %Y") %}
                     <li class="time-label">
                         {% if ns.last_day != ns.current_day %}
                         <span class="bg-blue bg-opencve">
@@ -48,7 +48,7 @@
                         <i class="fa fa-edit bg-blue"></i>
                         {% endif %}
                         <div class="timeline-item">
-                            <span class="time"><i class="fa fa-clock-o"></i> {{ change.created_at.strftime("%H:%M") }}</span>
+                            <span class="time" title="{{ change.created_at.strftime('%d %b %Y, %H:%M') }}"><i class="fa fa-clock-o"></i> {{ change.created_at.strftime("%H:%M") }}</span>
                             <h3 class="timeline-header"><a href="{{ url_for('main.cve', cve_id=change.cve.cve_id) }}">{{ change.cve.cve_id }}</a> {% if new %}is a new CVE{% else %}has changed{% endif %}</h3>
 
                             <div class="timeline-body">
@@ -128,7 +128,13 @@
                     {% endfor %}
                 </ul>
                 <div class="center">
-                    {{ pagination.links }}
+                    <ul class="pagination">
+                        {% set prev = page - 1 %}
+                        {% if prev %}
+                        <li class="previous"><a href="{{ url_for('main.home', page=prev) }}">  « prev </a></li>
+                        {% endif %}
+                        <li class="next"><a href="{{ url_for('main.home', page=page+1) }}">next »</a></li>
+                    </ul>
                 </div>
             {% endif %}
         </div>

--- a/tests/views/test_home.py
+++ b/tests/views/test_home.py
@@ -61,7 +61,7 @@ def test_subscription_without_changes(client, login):
 
     response = client.get("/")
     assert response.status_code == 200
-    assert b"Your subscriptions haven't changed yet." in response.data
+    assert b"No changes available." in response.data
 
 
 def test_activity_new_cve(client, login, handle_events):
@@ -86,7 +86,7 @@ def test_activity_cve_changed(client, login, create_cve, handle_events):
 
     response = client.get("/")
     assert response.status_code == 200
-    assert b"Your subscriptions haven't changed yet." in response.data
+    assert b"No changes available." in response.data
 
     handle_events("modified_cves/CVE-2018-18074_references.json")
     response = client.get("/")
@@ -100,7 +100,7 @@ def test_activity_cve_changed(client, login, create_cve, handle_events):
     )
 
 
-def test_list_paginated(app, client, login, handle_events):
+def test_list_paginated(app, client, login, handle_events, make_soup):
     old = app.config["ACTIVITIES_PER_PAGE"]
     app.config["ACTIVITIES_PER_PAGE"] = 2
 
@@ -115,23 +115,34 @@ def test_list_paginated(app, client, login, handle_events):
     # Changes are ordered using the lastModifiedDate field of each CVE
     response = client.get("/")
     assert response.status_code == 200
-    assert (
-        b'<a href="/cve/CVE-2019-17052">CVE-2019-17052</a> is a new CVE'
-        in response.data
-    )
-    assert (
-        b'<a href="/cve/CVE-2020-26116">CVE-2020-26116</a> is a new CVE'
-        in response.data
-    )
 
+    # Page 1
+    soup = make_soup(response.data)
+    dates = [s.find("span").text for s in soup.find_all(attrs={"class": "time-label"})]
+    assert "04 Jan 2021" in dates[0]
+    assert "19 Nov 2020" in dates[1]
+    dates = [
+        s.find("a").text for s in soup.find_all(attrs={"class": "timeline-header"})
+    ]
+    assert "CVE-2019-17052" in dates[0]
+    assert "CVE-2020-26116" in dates[1]
+
+    # Page 2
     response = client.get("/?page=2")
-    assert response.status_code == 200
-    assert (
-        b'<a href="/cve/CVE-2018-18074">CVE-2018-18074</a> is a new CVE'
-        in response.data
-    )
+    soup = make_soup(response.data)
+    dates = [s.find("span").text for s in soup.find_all(attrs={"class": "time-label"})]
+    assert "03 Oct 2019" in dates[0]
+    dates = [
+        s.find("a").text for s in soup.find_all(attrs={"class": "timeline-header"})
+    ]
+    assert "CVE-2018-18074" in dates[0]
 
+    # Other pages
     response = client.get("/?page=3")
-    assert response.status_code == 404
+    assert response.status_code == 200
+    assert b"No changes available." in response.data
+    response = client.get("/?page=300")
+    assert response.status_code == 200
+    assert b"No changes available." in response.data
 
     app.config["ACTIVITIES_PER_PAGE"] = old


### PR DESCRIPTION
This PR does 2 things:

- it fixes #133
- it increases the performance of the SQL query

The impact for the user is on the pagination: it's currently a full pagination (1, 2, 3, ...), with this PR it will be **prev** and **next** buttons (see the screenshot).

I used the `.paginate()` function of the `flask_sqlalchemy` package for the pagination (as always in OpenCVE, it works very well). But this function has to do 2 requests: a first one to fetch the objects (see [here](https://github.com/pallets/flask-sqlalchemy/blob/2.x/flask_sqlalchemy/__init__.py#L534)), and a second one to count the total of objects (see [here](https://github.com/pallets/flask-sqlalchemy/blob/2.x/flask_sqlalchemy/__init__.py#L539)).

The second one is just need to have the total number of objects and give it as the last item of the pagination. Just using **prev** & **next** keywords I don't need this last item, so the performance is increased (almost x2).

BTW I also updated the tests to check the order of changes.

![image](https://user-images.githubusercontent.com/1552526/130372451-773ab233-6196-49ee-ac6d-c5c3a4a33219.png)
