### PR TITLE
feat: display recorded change history for CVEs

### DIFF
--- a/opencve/templates/cve.html
+++ b/opencve/templates/cve.html
@@ -146,6 +146,47 @@
                 </div>
                 {% endif %}
             </div>
+
+            <div class="box box-primary">
+                <div class="box-header">
+                    <div class="box-title">History</div>
+                    <div class="box-tools pull-right">
+                        <button type="button" class="btn btn-box-tool" data-widget="collapse"><i
+                                class="fa fa-minus"></i></button>
+                    </div>
+                </div>
+                <div class="box-body">
+                    <table class="table">
+                        <thead>
+                            <th class="col-md-1">Time</th>
+                            <th class="col-md-10">Events</th>
+                        </thead>
+                        <tbody>
+                            {% for time, events in events_by_time %}
+                                <tr>
+                                    <td>{{ time }}</td>
+                                    <td>
+                                        <table class="table table-bordered table-striped">
+                                            <thead>
+                                                <th>Type</th>
+                                                <th class="col-md-6">Values Removed</th>
+                                                <th class="col-md-6">Values Added</th>
+                                            </thead>
+                                            <tbody>
+                                                {% for event in events %}
+                                                    {% set template = 'report/' + event.type.code + '_details.html' %}
+                                                    {% include template %}
+                                                {% endfor %}
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </table>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
 
         <div class="col-md-3">

--- a/opencve/templates/cve.html
+++ b/opencve/templates/cve.html
@@ -159,7 +159,7 @@
                     <table class="table">
                         <thead>
                             <th class="col-md-1">Time</th>
-                            <th class="col-md-10">Events</th>
+                            <th class="col-md-11">Events</th>
                         </thead>
                         <tbody>
                         {% for time, events in events_by_time %}
@@ -168,9 +168,9 @@
                                 <td>
                                     <table class="table table-bordered table-striped">
                                         <thead>
-                                            <th>Type</th>
-                                            <th class="col-md-6">Values Removed</th>
-                                            <th class="col-md-6">Values Added</th>
+                                            <th class="col-md-1">Type</th>
+                                            <th class="col-md-5">Values Removed</th>
+                                            <th class="col-md-5">Values Added</th>
                                         </thead>
                                         <tbody>
                                         {% for event in events %}

--- a/opencve/templates/cve.html
+++ b/opencve/templates/cve.html
@@ -162,27 +162,26 @@
                             <th class="col-md-10">Events</th>
                         </thead>
                         <tbody>
-                            {% for time, events in events_by_time %}
-                                <tr>
-                                    <td>{{ time }}</td>
-                                    <td>
-                                        <table class="table table-bordered table-striped">
-                                            <thead>
-                                                <th>Type</th>
-                                                <th class="col-md-6">Values Removed</th>
-                                                <th class="col-md-6">Values Added</th>
-                                            </thead>
-                                            <tbody>
-                                                {% for event in events %}
-                                                    {% set template = 'report/' + event.type.code + '_details.html' %}
-                                                    {% include template %}
-                                                {% endfor %}
-                                            </tbody>
-                                        </table>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </table>
+                        {% for time, events in events_by_time %}
+                            <tr>
+                                <td>{{ time }}</td>
+                                <td>
+                                    <table class="table table-bordered table-striped">
+                                        <thead>
+                                            <th>Type</th>
+                                            <th class="col-md-6">Values Removed</th>
+                                            <th class="col-md-6">Values Added</th>
+                                        </thead>
+                                        <tbody>
+                                        {% for event in events %}
+                                            {% set template = 'report/' + event.type.code + '_details.html' %}
+                                            {% include template %}
+                                        {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                        {% endfor %}
                         </tbody>
                     </table>
                 </div>

--- a/opencve/templates/cve.html
+++ b/opencve/templates/cve.html
@@ -155,6 +155,7 @@
                                 class="fa fa-minus"></i></button>
                     </div>
                 </div>
+                {% if events_by_time %}
                 <div class="box-body">
                     <table class="table">
                         <thead>
@@ -185,6 +186,11 @@
                         </tbody>
                     </table>
                 </div>
+                {% else %}
+                <div class="box-body">
+                    <p class="alert alert-info">No history.</p>
+                </div>
+                {% endif %}
             </div>
         </div>
 

--- a/opencve/templates/report/new_cve_details.html
+++ b/opencve/templates/report/new_cve_details.html
@@ -1,5 +1,3 @@
 <tr>
-    <td>New CVE</td>
-    <td></td>
-    <td></td>
+    <td colspan="3"><b>New&nbsp;CVE</b></td>
 </tr>

--- a/tests/views/test_cves.py
+++ b/tests/views/test_cves.py
@@ -50,3 +50,4 @@ def test_get_cve(client, create_cve, create_cwe):
     assert b"<li>ubuntu_linux</li>" in response.data
     assert b"<strong>python-requests</strong>" in response.data
     assert b"<li>requests</li>" in response.data
+    assert b"No history." in response.data

--- a/tests/views/test_reports.py
+++ b/tests/views/test_reports.py
@@ -63,5 +63,5 @@ def test_get_report(mock_send, client, login, handle_events):
     assert b"Canonical" in response.data
     assert b"CVE-2018-18074" in response.data
     assert b"9.8" in response.data
-    assert b"New CVE" in response.data
+    assert b"New&nbsp;CVE" in response.data
     db.session.commit()


### PR DESCRIPTION
The CVE view now shows recorded change history using parts of the report view.

This is how it looks: 
![image](https://user-images.githubusercontent.com/18428519/143719031-c49f65be-76ec-4458-94f9-f242809ddd55.png)

Ideas on better design/formatting are welcome!