### PR TITLE
feat: add the first_time event

### DIFF
--- a/opencve/checks/first_time.py
+++ b/opencve/checks/first_time.py
@@ -1,0 +1,19 @@
+from opencve.checks import BaseCheck
+from opencve.commands.utils import CveUtil
+from opencve.extensions import db
+from opencve.utils import convert_cpes, flatten_vendors
+
+
+class FirstTime(BaseCheck):
+    def execute(self):
+        old = flatten_vendors(convert_cpes(self.cve_obj.json["configurations"]))
+        new = flatten_vendors(convert_cpes(self.cve_json["configurations"]))
+        payload = list(set(new) - set(old))
+
+        if payload:
+            event = CveUtil.create_event(
+                self.cve_obj, self.cve_json, "first_time", payload
+            )
+            return event
+
+        return None

--- a/opencve/constants.py
+++ b/opencve/constants.py
@@ -1,6 +1,7 @@
 # Used in the Events and Alerts tables
 EVENT_TYPES = [
     ("new_cve", "New CVE"),
+    ("first_time", "Subscription appeared for the first time"),
     ("references", "References changed"),
     ("cpes", "CPEs changed"),
     ("cvss", "CVSS changed"),

--- a/opencve/forms.py
+++ b/opencve/forms.py
@@ -78,6 +78,7 @@ class MailNotificationsForm(FlaskForm):
 
 class FiltersNotificationForm(FlaskForm):
     new_cve = BooleanField("New CVE")
+    first_time = BooleanField("Subscription appeared for the first time")
     references = BooleanField("Reference changed")
     cvss = BooleanField("CVSS changed")
     cpes = BooleanField("CPE changed")

--- a/opencve/migrations/versions/2132d05ea0e2_add_first_time_value_in_event_types_enum.py
+++ b/opencve/migrations/versions/2132d05ea0e2_add_first_time_value_in_event_types_enum.py
@@ -1,0 +1,30 @@
+"""Add first_time value in event_types enum
+
+Revision ID: 2132d05ea0e2
+Revises: 4195eeb432e9
+Create Date: 2021-12-19 22:59:41.176119
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "2132d05ea0e2"
+down_revision = "4195eeb432e9"
+
+from alembic import op
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE event_types ADD VALUE 'first_time';")
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE TYPE event_types_new AS ENUM ('new_cve', 'references', 'cpes', 'cvss', 'summary', 'cwes');"
+        )
+        op.execute(
+            "ALTER TABLE events ALTER COLUMN type TYPE event_types_new USING (type::text::event_types_new);"
+        )
+        op.execute("DROP TYPE event_types;")
+        op.execute("ALTER TYPE event_types_new RENAME TO event_types;")

--- a/opencve/models/users.py
+++ b/opencve/models/users.py
@@ -11,7 +11,15 @@ from opencve.models import BaseModel, users_products, users_vendors
 def get_default_filters():
     return {
         "cvss": 0,
-        "event_types": ["new_cve", "references", "cvss", "cpes", "summary", "cwes"],
+        "event_types": [
+            "new_cve",
+            "first_time",
+            "references",
+            "cvss",
+            "cpes",
+            "summary",
+            "cwes",
+        ],
     }
 
 

--- a/opencve/templates/profiles/notifications.html
+++ b/opencve/templates/profiles/notifications.html
@@ -17,17 +17,23 @@
                     <input type="hidden" name="form-name" value="filters_notifications_form">
 
                     <div class="form-group">
-                        <label>When a new CVE is created :</label>
+                        <label>Receive a notification when:</label>
                         <div class="checkbox">
                             <label>
                                 {{ filters_notifications_form.new_cve() }}
-                                be alerted
+                                a new CVE is created
+                            </label>
+                        </div>
+                        <div class="checkbox">
+                            <label>
+                                {{ filters_notifications_form.first_time() }}
+                                one of your subscriptions appears for the first time in an existing CVE
                             </label>
                         </div>
                     </div>
 
                     <div class="form-group">
-                        <label>When a CVE is updated, be alerted when :</label>
+                        <label>When a CVE is updated, receive a notification when:</label>
                         <div class="checkbox">
                             <label>
                                 {{ filters_notifications_form.cvss() }}
@@ -61,7 +67,7 @@
                     </div>
 
                     <div class="form-group">
-                        <label>Be alerted when the CVSSv3 score is greater than or equal to :</label>
+                        <label>Receive a notification when the CVSSv3 score is greater than or equal to :</label>
                         {{ filters_notifications_form.cvss_score(class_="form-control") }}
                         <span class="help-block"><small>Note that this setting does not affect CVE that do not have CVSS.</small></span>
                     </div>

--- a/opencve/views/profile.py
+++ b/opencve/views/profile.py
@@ -35,6 +35,7 @@ def notifications():
     filters_notifications_form = FiltersNotificationForm(
         obj=current_user,
         new_cve=True if "new_cve" in filters["event_types"] else False,
+        first_time=True if "first_time" in filters["event_types"] else False,
         references=True if "references" in filters["event_types"] else False,
         cvss=True if "cvss" in filters["event_types"] else False,
         cpes=True if "cpes" in filters["event_types"] else False,
@@ -72,7 +73,15 @@ def notifications():
                 "cvss": filters_notifications_form.cvss_score.data,
             }
 
-            for typ in ["new_cve", "references", "cvss", "cpes", "cwes", "summary"]:
+            for typ in [
+                "new_cve",
+                "first_time",
+                "references",
+                "cvss",
+                "cpes",
+                "cwes",
+                "summary",
+            ]:
                 if getattr(filters_notifications_form, typ).data:
                     filters["event_types"].append(typ)
 

--- a/tests/checks/test_cpes.py
+++ b/tests/checks/test_cpes.py
@@ -70,9 +70,7 @@ def test_check_cpes(create_cve, handle_events, open_file):
     }
 
     # Event has been created
-    events = Event.query.all()
-    assert len(events) == 1
-    event = events[0]
+    event = Event.query.filter_by(type="cpes").first()
     assert event.type == "cpes"
     assert event.details == {
         "added": ["cpe:2.3:a:opencveio:opencve:*:*:*:*:*:*:*:*"],

--- a/tests/checks/test_first_time.py
+++ b/tests/checks/test_first_time.py
@@ -1,0 +1,43 @@
+from opencve.constants import PRODUCT_SEPARATOR
+from opencve.models.cve import Cve
+from opencve.models.changes import Change
+from opencve.models.events import Event
+from opencve.models.products import Product
+from opencve.models.tasks import Task
+from opencve.models.vendors import Vendor
+from opencve.utils import convert_cpes
+
+
+def test_check_first_time(create_cve, handle_events):
+    """
+    This test demontrates the difference between the `cpes` and `first_time`
+    events. While the first one will always been triggered when a new CPE is updated,
+    the second one will just been triggered for the first apparition of the vendor.
+    """
+    create_cve("CVE-2018-18074")
+
+    vendors = Vendor.query.all()
+    assert len(vendors) == 2
+    assert sorted([v.name for v in vendors]) == sorted(["python-requests", "canonical"])
+
+    # This version adds a new CPE (cpe:2.3:a:opencveio:opencve:1:*:*:*:*:*:*:*)
+    handle_events("modified_cves/CVE-2018-18074_first_time_1.json")
+
+    # 2 events: `cpes` and `first_time`
+    events = Event.query.all()
+    assert len(events) == 2
+    assert sorted([e.type.code for e in events]) == ["cpes", "first_time"]
+
+    # The `fist_time event` contains the new vendors in its details
+    event = Event.query.filter_by(type="first_time").first()
+    assert sorted(event.details) == ["opencveio", "opencveio$PRODUCT$opencve"]
+
+    # This version adds a new CPE (cpe:2.3:a:opencveio:opencve:2:*:*:*:*:*:*:*)
+    handle_events("modified_cves/CVE-2018-18074_first_time_2.json")
+
+    # Another `cpes` event has been triggered, but not the `first_time` one
+    # because the `opencveio` vendor and `opencve` product have already appeared
+    # in a previous event.
+    events = Event.query.all()
+    assert len(events) == 3
+    assert sorted([e.type.code for e in events]) == ["cpes", "cpes", "first_time"]

--- a/tests/data/modified_cves/CVE-2018-18074_first_time_1.json
+++ b/tests/data/modified_cves/CVE-2018-18074_first_time_1.json
@@ -1,0 +1,140 @@
+[{
+    "cve": {
+        "data_type": "CVE",
+        "references": {
+            "reference_data": [{
+                "url": "http://docs.python-requests.org/en/master/community/updates/#release-and-version-history",
+                "name": "http://docs.python-requests.org/en/master/community/updates/#release-and-version-history",
+                "tags": ["Release Notes", "Third Party Advisory"],
+                "refsource": "CONFIRM"
+            }, {
+                "url": "http://lists.opensuse.org/opensuse-security-announce/2019-07/msg00024.html",
+                "name": "openSUSE-SU-2019:1754",
+                "tags": [],
+                "refsource": "SUSE"
+            }, {
+                "url": "https://access.redhat.com/errata/RHSA-2019:2035",
+                "name": "RHSA-2019:2035",
+                "tags": [],
+                "refsource": "REDHAT"
+            }, {
+                "url": "https://bugs.debian.org/910766",
+                "name": "https://bugs.debian.org/910766",
+                "tags": ["Exploit", "Issue Tracking", "Patch", "Third Party Advisory"],
+                "refsource": "MISC"
+            }, {
+                "url": "https://github.com/requests/requests/commit/c45d7c49ea75133e52ab22a8e9e13173938e36ff",
+                "name": "https://github.com/requests/requests/commit/c45d7c49ea75133e52ab22a8e9e13173938e36ff",
+                "tags": ["Patch", "Third Party Advisory"],
+                "refsource": "MISC"
+            }, {
+                "url": "https://github.com/requests/requests/issues/4716",
+                "name": "https://github.com/requests/requests/issues/4716",
+                "tags": ["Exploit", "Patch", "Third Party Advisory"],
+                "refsource": "MISC"
+            }, {
+                "url": "https://github.com/requests/requests/pull/4718",
+                "name": "https://github.com/requests/requests/pull/4718",
+                "tags": ["Patch", "Third Party Advisory"],
+                "refsource": "MISC"
+            }, {
+                "url": "https://usn.ubuntu.com/3790-1/",
+                "name": "USN-3790-1",
+                "tags": ["Third Party Advisory"],
+                "refsource": "UBUNTU"
+            }, {
+                "url": "https://usn.ubuntu.com/3790-2/",
+                "name": "USN-3790-2",
+                "tags": ["Third Party Advisory"],
+                "refsource": "UBUNTU"
+            }]
+        },
+        "data_format": "MITRE",
+        "description": {
+            "description_data": [{
+                "lang": "en",
+                "value": "The Requests package before 2.20.0 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network."
+            }]
+        },
+        "problemtype": {
+            "problemtype_data": [{
+                "description": [{
+                    "lang": "en",
+                    "value": "CWE-522"
+                }]
+            }]
+        },
+        "data_version": "4.0",
+        "CVE_data_meta": {
+            "ID": "CVE-2018-18074",
+            "ASSIGNER": "cve@mitre.org"
+        }
+    },
+    "impact": {
+        "baseMetricV2": {
+            "cvssV2": {
+                "version": "2.0",
+                "baseScore": 5.0,
+                "accessVector": "NETWORK",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+                "authentication": "NONE",
+                "integrityImpact": "NONE",
+                "accessComplexity": "LOW",
+                "availabilityImpact": "NONE",
+                "confidentialityImpact": "PARTIAL"
+            },
+            "severity": "MEDIUM",
+            "impactScore": 2.9,
+            "obtainAllPrivilege": false,
+            "exploitabilityScore": 10.0,
+            "obtainUserPrivilege": false,
+            "obtainOtherPrivilege": false,
+            "userInteractionRequired": false
+        },
+        "baseMetricV3": {
+            "cvssV3": {
+                "scope": "UNCHANGED",
+                "version": "3.0",
+                "baseScore": 9.8,
+                "attackVector": "NETWORK",
+                "baseSeverity": "CRITICAL",
+                "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "integrityImpact": "HIGH",
+                "userInteraction": "NONE",
+                "attackComplexity": "LOW",
+                "availabilityImpact": "HIGH",
+                "privilegesRequired": "NONE",
+                "confidentialityImpact": "HIGH"
+            },
+            "impactScore": 5.9,
+            "exploitabilityScore": 3.9
+        }
+    },
+    "publishedDate": "2018-10-09T17:29Z",
+    "configurations": {
+        "nodes": [{
+            "operator": "OR",
+            "cpe_match": [{
+                "cpe23Uri": "cpe:2.3:a:opencveio:opencve:1:*:*:*:*:*:*:*",
+                "vulnerable": true
+            }]
+        }, {
+            "operator": "OR",
+            "cpe_match": [{
+                "cpe23Uri": "cpe:2.3:o:canonical:ubuntu_linux:14.04:*:*:*:lts:*:*:*",
+                "vulnerable": true
+            }, {
+                "cpe23Uri": "cpe:2.3:o:canonical:ubuntu_linux:16.04:*:*:*:lts:*:*:*",
+                "vulnerable": true
+            }, {
+                "cpe23Uri": "cpe:2.3:o:canonical:ubuntu_linux:18.04:*:*:*:lts:*:*:*",
+                "vulnerable": true
+            }, {
+                "cpe23Uri": "cpe:2.3:o:canonical:ubuntu_linux:18.10:*:*:*:*:*:*:*",
+                "vulnerable": true
+            }]
+        }],
+        "CVE_data_version": "4.0"
+    },
+    "lastModifiedDate": "2019-10-03T13:37Z"
+}]

--- a/tests/data/modified_cves/CVE-2018-18074_first_time_2.json
+++ b/tests/data/modified_cves/CVE-2018-18074_first_time_2.json
@@ -1,0 +1,143 @@
+[{
+    "cve": {
+        "data_type": "CVE",
+        "references": {
+            "reference_data": [{
+                "url": "http://docs.python-requests.org/en/master/community/updates/#release-and-version-history",
+                "name": "http://docs.python-requests.org/en/master/community/updates/#release-and-version-history",
+                "tags": ["Release Notes", "Third Party Advisory"],
+                "refsource": "CONFIRM"
+            }, {
+                "url": "http://lists.opensuse.org/opensuse-security-announce/2019-07/msg00024.html",
+                "name": "openSUSE-SU-2019:1754",
+                "tags": [],
+                "refsource": "SUSE"
+            }, {
+                "url": "https://access.redhat.com/errata/RHSA-2019:2035",
+                "name": "RHSA-2019:2035",
+                "tags": [],
+                "refsource": "REDHAT"
+            }, {
+                "url": "https://bugs.debian.org/910766",
+                "name": "https://bugs.debian.org/910766",
+                "tags": ["Exploit", "Issue Tracking", "Patch", "Third Party Advisory"],
+                "refsource": "MISC"
+            }, {
+                "url": "https://github.com/requests/requests/commit/c45d7c49ea75133e52ab22a8e9e13173938e36ff",
+                "name": "https://github.com/requests/requests/commit/c45d7c49ea75133e52ab22a8e9e13173938e36ff",
+                "tags": ["Patch", "Third Party Advisory"],
+                "refsource": "MISC"
+            }, {
+                "url": "https://github.com/requests/requests/issues/4716",
+                "name": "https://github.com/requests/requests/issues/4716",
+                "tags": ["Exploit", "Patch", "Third Party Advisory"],
+                "refsource": "MISC"
+            }, {
+                "url": "https://github.com/requests/requests/pull/4718",
+                "name": "https://github.com/requests/requests/pull/4718",
+                "tags": ["Patch", "Third Party Advisory"],
+                "refsource": "MISC"
+            }, {
+                "url": "https://usn.ubuntu.com/3790-1/",
+                "name": "USN-3790-1",
+                "tags": ["Third Party Advisory"],
+                "refsource": "UBUNTU"
+            }, {
+                "url": "https://usn.ubuntu.com/3790-2/",
+                "name": "USN-3790-2",
+                "tags": ["Third Party Advisory"],
+                "refsource": "UBUNTU"
+            }]
+        },
+        "data_format": "MITRE",
+        "description": {
+            "description_data": [{
+                "lang": "en",
+                "value": "The Requests package before 2.20.0 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network."
+            }]
+        },
+        "problemtype": {
+            "problemtype_data": [{
+                "description": [{
+                    "lang": "en",
+                    "value": "CWE-522"
+                }]
+            }]
+        },
+        "data_version": "4.0",
+        "CVE_data_meta": {
+            "ID": "CVE-2018-18074",
+            "ASSIGNER": "cve@mitre.org"
+        }
+    },
+    "impact": {
+        "baseMetricV2": {
+            "cvssV2": {
+                "version": "2.0",
+                "baseScore": 5.0,
+                "accessVector": "NETWORK",
+                "vectorString": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+                "authentication": "NONE",
+                "integrityImpact": "NONE",
+                "accessComplexity": "LOW",
+                "availabilityImpact": "NONE",
+                "confidentialityImpact": "PARTIAL"
+            },
+            "severity": "MEDIUM",
+            "impactScore": 2.9,
+            "obtainAllPrivilege": false,
+            "exploitabilityScore": 10.0,
+            "obtainUserPrivilege": false,
+            "obtainOtherPrivilege": false,
+            "userInteractionRequired": false
+        },
+        "baseMetricV3": {
+            "cvssV3": {
+                "scope": "UNCHANGED",
+                "version": "3.0",
+                "baseScore": 9.8,
+                "attackVector": "NETWORK",
+                "baseSeverity": "CRITICAL",
+                "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "integrityImpact": "HIGH",
+                "userInteraction": "NONE",
+                "attackComplexity": "LOW",
+                "availabilityImpact": "HIGH",
+                "privilegesRequired": "NONE",
+                "confidentialityImpact": "HIGH"
+            },
+            "impactScore": 5.9,
+            "exploitabilityScore": 3.9
+        }
+    },
+    "publishedDate": "2018-10-09T17:29Z",
+    "configurations": {
+        "nodes": [{
+            "operator": "OR",
+            "cpe_match": [{
+                "cpe23Uri": "cpe:2.3:a:opencveio:opencve:1:*:*:*:*:*:*:*",
+                "vulnerable": true
+            }, {
+                "cpe23Uri": "cpe:2.3:a:opencveio:opencve:2:*:*:*:*:*:*:*",
+                "vulnerable": true
+            }]
+        }, {
+            "operator": "OR",
+            "cpe_match": [{
+                "cpe23Uri": "cpe:2.3:o:canonical:ubuntu_linux:14.04:*:*:*:lts:*:*:*",
+                "vulnerable": true
+            }, {
+                "cpe23Uri": "cpe:2.3:o:canonical:ubuntu_linux:16.04:*:*:*:lts:*:*:*",
+                "vulnerable": true
+            }, {
+                "cpe23Uri": "cpe:2.3:o:canonical:ubuntu_linux:18.04:*:*:*:lts:*:*:*",
+                "vulnerable": true
+            }, {
+                "cpe23Uri": "cpe:2.3:o:canonical:ubuntu_linux:18.10:*:*:*:*:*:*:*",
+                "vulnerable": true
+            }]
+        }],
+        "CVE_data_version": "4.0"
+    },
+    "lastModifiedDate": "2021-12-21T13:37Z"
+}]


### PR DESCRIPTION
Most of the time the NVD creates new CVE without associated CPE, which means the **new_cve** type is not really useful (because no vendor and product are associated, so OpenCVE doesn't have subscribers to alerts).

Then some CPEs are associated, now OpenCVE can triggered an alert with the **cpes** type for the users who subscribed on vendors or products. But these users will receive an alert for each addition/deletion of CPE, even for vendors/products they're not interested in.

With this new **first_time** type the users will be alerted when their subscriptions will appear in an existing CVE. After that, even if the CPE will change, the users with the who check the **first_time** notification option will not be alerted.

<img width="691" alt="Capture d’écran 2021-12-23 à 16 53 17" src="https://user-images.githubusercontent.com/1552526/147266272-f38e8bff-02d1-4ddc-95b1-7a292e12d98f.png">

This PR closes #157. 