### PR TITLE
feat: display change date in a human format in CVE history

### DIFF
--- a/opencve/templates/cve.html
+++ b/opencve/templates/cve.html
@@ -157,34 +157,27 @@
                 </div>
                 {% if events_by_time %}
                 <div class="box-body">
-                    <table class="table">
-                        <thead>
-                            <th class="col-md-1">Time</th>
-                            <th class="col-md-11">Events</th>
-                        </thead>
-                        <tbody>
-                        {% for time, events in events_by_time %}
-                            <tr>
-                                <td>{{ time }}</td>
-                                <td>
-                                    <table class="table table-bordered table-striped">
-                                        <thead>
-                                            <th class="col-md-1">Type</th>
-                                            <th class="col-md-5">Values Removed</th>
-                                            <th class="col-md-5">Values Added</th>
-                                        </thead>
-                                        <tbody>
-                                        {% for event in events %}
-                                            {% set template = 'report/' + event.type.code + '_details.html' %}
-                                            {% include template %}
-                                        {% endfor %}
-                                        </tbody>
-                                    </table>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
+                    <div class="row">
+                        <div class="col-md-12">
+                            {% for time, events in events_by_time %}
+                            <p><strong><i class="fa fa-clock-o"></i> {{ time.strftime("%d %b %Y, %H:%M") }}</strong></p>
+                            <table class="table table-bordered table-striped">
+                                <thead>
+                                    <th>Type</th>
+                                    <th>Values Removed</th>
+                                    <th>Values Added</th>
+                                </thead>
+                                <tbody>
+                                {% for event in events %}
+                                    {% set template = 'report/' + event.type.code + '_details.html' %}
+                                    {% include template %}
+                                {% endfor %}
+                                </tbody>
+                            </table>
+                            <hr />
+                            {% endfor %}
+                        </div>
+                    </div>
                 </div>
                 {% else %}
                 <div class="box-body">


### PR DESCRIPTION
Not a big change, the idea was just to reformat the date to be more easily readable. I took the opportunity to flat the table and display the date as a title.

Before
<img width="1029" alt="Capture d’écran 2021-12-24 à 11 22 39" src="https://user-images.githubusercontent.com/1552526/147344560-f3d38f35-84b3-401c-bb3e-4a2f0de63b4c.png">

After
<img width="1033" alt="Capture d’écran 2021-12-24 à 11 22 52" src="https://user-images.githubusercontent.com/1552526/147344572-980e7181-2aeb-430c-bca5-9234bfe9334c.png">

