### PR TITLE
Add tags in dashboard

### DIFF
--- a/opencve/context.py
+++ b/opencve/context.py
@@ -1,9 +1,9 @@
 from flask import current_app as app
 from flask import request, url_for
+from flask_user import current_user
 
 from opencve.constants import EVENT_TYPES, PRODUCT_SEPARATOR
 from opencve.models.tags import UserTag
-from flask_user import current_user
 
 
 def _cvss_percent(score):
@@ -118,16 +118,15 @@ def _excerpt(objects, _type):
             vendor, product = obj.split(PRODUCT_SEPARATOR)
             url = url_for("main.cves", vendor=vendor, product=product)
             output += f"<a href='{url}'>{_humanize_filter(product)}</a>"
-        elif _type == "vendors" :
+        elif _type == "vendors":
             url = url_for("main.cves", vendor=obj)
             output += f"<a href='{url}'>{_humanize_filter(obj)}</a>"
         else:
             url = url_for("main.cves", tag=obj)
             tag = UserTag.query.filter_by(user_id=current_user.id, name=obj).first()
-            bgcolor = tag.color
-            output += f"<a href='{url}'><span class='label label-tag' style='background-color: {bgcolor};'>{obj}</span></a>"
+            output += f"<a href='{url}'><span class='label label-tag' style='background-color: {tag.color};'>{obj}</span></a>"
 
-        output += ", " if idx + 1 != len(objects) else " "
+        output += ", " if idx + 1 != len(objects) and _type != "tags" else " "
 
     if remains:
         output += "<i>and {} more</i>".format(remains)

--- a/opencve/context.py
+++ b/opencve/context.py
@@ -2,6 +2,8 @@ from flask import current_app as app
 from flask import request, url_for
 
 from opencve.constants import EVENT_TYPES, PRODUCT_SEPARATOR
+from opencve.models.tags import UserTag
+from flask_user import current_user
 
 
 def _cvss_percent(score):
@@ -116,9 +118,14 @@ def _excerpt(objects, _type):
             vendor, product = obj.split(PRODUCT_SEPARATOR)
             url = url_for("main.cves", vendor=vendor, product=product)
             output += f"<a href='{url}'>{_humanize_filter(product)}</a>"
-        else:
+        elif _type == "vendors" :
             url = url_for("main.cves", vendor=obj)
             output += f"<a href='{url}'>{_humanize_filter(obj)}</a>"
+        else:
+            url = url_for("main.cves", tag=obj)
+            tag = UserTag.query.filter_by(user_id=current_user.id, name=obj).first()
+            bgcolor = tag.color
+            output += f"<a href='{url}'><span class='label label-tag' style='background-color: {bgcolor};'>{obj}</span></a>"
 
         output += ", " if idx + 1 != len(objects) else " "
 

--- a/opencve/controllers/main.py
+++ b/opencve/controllers/main.py
@@ -73,9 +73,11 @@ def vendors_excerpt(s):
 def products_excerpt(s):
     return _excerpt(s, "products")
 
+
 @main.app_template_filter("tags_excerpt")
 def tags_excerpt(s):
     return _excerpt(s, "tags")
+
 
 @main.app_template_filter("report_excerpt")
 def report_excerpt(s):

--- a/opencve/controllers/main.py
+++ b/opencve/controllers/main.py
@@ -73,6 +73,9 @@ def vendors_excerpt(s):
 def products_excerpt(s):
     return _excerpt(s, "products")
 
+@main.app_template_filter("tags_excerpt")
+def tags_excerpt(s):
+    return _excerpt(s, "tags")
 
 @main.app_template_filter("report_excerpt")
 def report_excerpt(s):

--- a/opencve/templates/home.html
+++ b/opencve/templates/home.html
@@ -53,7 +53,6 @@
                         <div class="timeline-item">
                             <span class="time" title="{{ change.created_at.strftime('%d %b %Y, %H:%M') }}"><i class="fa fa-clock-o"></i> {{ change.created_at.strftime("%H:%M") }}</span>
                             <h3 class="timeline-header"><a href="{{ url_for('main.cve', cve_id=change.cve.cve_id) }}">{{ change.cve.cve_id }}</a> {% if new %}is a new CVE{% else %}has changed{% endif %} <a href="{{ url_for('main.cve_change', cve_id=change.cve.cve_id, change_id=change.id) }}" class="btn-json-diff" data-toggle="tooltip" data-container="body" title="View the change details"><i class="fa fa-code"></i></a></h3>
-
                             <div class="timeline-body">
                                 <div class="row">
                                     <div class="col-md-9">
@@ -116,16 +115,26 @@
                                     <thead>
                                         <th>Vendors</th>
                                         <th>Products</th>
-					<th>Tags</th>
                                     </thead>
                                     <tbody>
                                         <tr>
                                             <td>{{ change.cve.vendors|vendors_excerpt|safe }}</td>
                                             <td>{{ change.cve.vendors|products_excerpt|safe }}</td>
-					    <td>{{ change.cve.raw_tags|tags_excerpt|safe }}</td>
                                         </tr>
                                     </tbody>
                                 </table>
+				{% if change.cve.raw_tags %}
+                               <table class="table timeline-footer no-margin-bottom">
+                                    <thead>
+                                        <th>Tags</th>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>{{ change.cve.raw_tags|tags_excerpt|safe }}</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+				{% endif %}
                             </div>
                         </div>
                     </li>

--- a/opencve/templates/home.html
+++ b/opencve/templates/home.html
@@ -116,11 +116,13 @@
                                     <thead>
                                         <th>Vendors</th>
                                         <th>Products</th>
+					<th>Tags</th>
                                     </thead>
                                     <tbody>
                                         <tr>
                                             <td>{{ change.cve.vendors|vendors_excerpt|safe }}</td>
                                             <td>{{ change.cve.vendors|products_excerpt|safe }}</td>
+					    <td>{{ change.cve.raw_tags|tags_excerpt|safe }}</td>
                                         </tr>
                                     </tbody>
                                 </table>


### PR DESCRIPTION
Partially resolve #166 as it add tags in the dashboard view. But it still needs the part where a tag is automatically added when an event is triggered on a subscribed CVE