### PR TITLE
Improve import data memory footprint

### DIFF
--- a/opencve/commands/imports/cve.py
+++ b/opencve/commands/imports/cve.py
@@ -43,7 +43,9 @@ def run():
         # Parse the XML elements
         with timed_operation("Parsing JSON elements..."):
             raw = gzip.GzipFile(fileobj=BytesIO(resp)).read()
+            del resp
             items = json.loads(raw.decode("utf-8"))["CVE_Items"]
+            del raw
 
         with timed_operation("Creating model objects..."):
 


### PR DESCRIPTION
Hi all,

To make the data import easier, this PR improve the memory footprint of the import script.

`xml.etree.ElementTree.iterparse()` loads XML tag one by one, and the `.clear()` deletes relations between tags, allowing the garbage collector to remove no more used tag. With this patch, the memory footprint of the CPE XML parsing is almost null :)

Warnings:
- This code does not take the XML hierarchy into account, it takes all the `cpe23-item` tags, We could take it into account, but the code will be more complex :/
- The python `xml` module shows a security warning in the [doc](https://docs.python.org/3/library/xml.etree.elementtree.html) but as untangle is built over it, that's not worst than before. (And in our case, i think we can trust the XML file)

With this patch, I have successfully imported data on my 4GB laptop with chromium opened :D

Hope this will be useful :)