### PR TITLE
Update report_message.html

### DIFF
--- a/opencve/templates/emails/report_message.html
+++ b/opencve/templates/emails/report_message.html
@@ -290,7 +290,7 @@ Respmail v1.1 (http://charlesmudy.com/respmail/)
                                                                        width="100%">
                                                                     <tr>
                                                                         <td valign="top" class="textContent">
-                                                                            <h3 style="color:#5F5F5F;line-height:25%;font-family:Helvetica,Arial,sans-serif;font-size:20px;font-weight:normal;margin-top:0;margin-bottom:3px;">
+                                                                            <h3 style="color:#5F5F5F;line-height:100%;font-family:Helvetica,Arial,sans-serif;font-size:20px;font-weight:normal;margin-top:0;margin-bottom:3px;">
                                                                                 {{ alerts.name }}
                                                                             </h3>
                                                                         </td>


### PR DESCRIPTION
Bug fixing to show alerts.name properly in Outlook emails. Before it was limited to 25% and not readable.