### PR TITLE
Update references.py

### DIFF
--- a/opencve/checks/references.py
+++ b/opencve/checks/references.py
@@ -38,7 +38,7 @@ class References(BaseCheck):
         modified_urls = list(
             set(
                 [
-                    r.split("'")[1]
+                    r.split("'][")[0].split("['")[1]
                     for r in list(diff.get("values_changed", {}).keys())
                     + list(diff.get("iterable_item_added", {}).keys())
                 ]

--- a/tests/checks/test_references.py
+++ b/tests/checks/test_references.py
@@ -84,3 +84,47 @@ def test_check_references(create_cve, handle_events, open_file):
             "http://lists.opensuse.org/opensuse-security-announce/2019-07/msg00024.html",
         ]
     )
+
+
+def test_check_references_with_quote(create_cve, handle_events, open_file):
+    cve = create_cve("CVE-2022-3122")
+    references = cve.json["cve"]["references"]["reference_data"]
+    assert len(references) == 2
+    assert [r["url"] for r in references] == [
+        "https://github.com/joinia/webray.com.cn/blob/main/Clinic's-Patient-Management-System/cpmssql.md",
+        "https://vuldb.com/?id.207854",
+    ]
+
+    # 1 modified reference
+    handle_events("modified_cves/CVE-2022-3122_references.json")
+    cve = Cve.query.filter_by(cve_id="CVE-2022-3122").first()
+
+    # Task has been created
+    tasks = Task.query.all()
+    assert len(tasks) == 1
+    task = tasks[0]
+
+    # Change has been created
+    changes = Change.query.all()
+    assert len(changes) == 1
+    change = changes[0]
+    assert change.task.id == task.id
+    references = change.json["cve"]["references"]["reference_data"]
+    assert len(references) == 2
+    assert sorted([r["url"] for r in references]) == sorted(
+        [
+            "https://github.com/joinia/webray.com.cn/blob/main/Clinic's-Patient-Management-System/cpmssql.md",
+            "https://vuldb.com/?id.207854",
+        ]
+    )
+
+    # Event has been created
+    events = Event.query.all()
+    assert len(events) == 1
+    event = events[0]
+    assert event.type == "references"
+
+    changed = event.details["changed"]
+    assert len(changed) == 1
+    assert changed[0]["old"]["tags"] == []
+    assert changed[0]["new"]["tags"] == ["Exploit", "Third Party Advisory"]

--- a/tests/data/cves/CVE-2022-3122.json
+++ b/tests/data/cves/CVE-2022-3122.json
@@ -1,0 +1,49 @@
+{
+  "cve": {
+    "data_type": "CVE",
+    "references": {
+      "reference_data": [
+        {
+          "url": "https://github.com/joinia/webray.com.cn/blob/main/Clinic's-Patient-Management-System/cpmssql.md",
+          "name": "https://github.com/joinia/webray.com.cn/blob/main/Clinic's-Patient-Management-System/cpmssql.md",
+          "tags": [],
+          "refsource": "MISC"
+        },
+        {
+          "url": "https://vuldb.com/?id.207854",
+          "name": "https://vuldb.com/?id.207854",
+          "tags": [],
+          "refsource": "MISC"
+        }
+      ]
+    },
+    "data_format": "MITRE",
+    "description": {
+      "description_data": [
+        {
+          "lang": "en",
+          "value": "A vulnerability was found in SourceCodester Clinics Patient Management System 1.0. It has been rated as critical. Affected by this issue is some unknown functionality of the file medicine_details.php. The manipulation of the argument medicine leads to sql injection. The attack may be launched remotely. The exploit has been disclosed to the public and may be used. VDB-207854 is the identifier assigned to this vulnerability."
+        }
+      ]
+    },
+    "problemtype": {
+      "problemtype_data": [
+        {
+          "description": []
+        }
+      ]
+    },
+    "data_version": "4.0",
+    "CVE_data_meta": {
+      "ID": "CVE-2022-3122",
+      "ASSIGNER": "cna@vuldb.com"
+    }
+  },
+  "impact": {},
+  "publishedDate": "2022-09-05T14:15Z",
+  "configurations": {
+    "nodes": [],
+    "CVE_data_version": "4.0"
+  },
+  "lastModifiedDate": "2022-09-06T04:07Z"
+}

--- a/tests/data/modified_cves/CVE-2022-3122_references.json
+++ b/tests/data/modified_cves/CVE-2022-3122_references.json
@@ -1,0 +1,49 @@
+[{
+  "cve": {
+    "data_type": "CVE",
+    "references": {
+      "reference_data": [
+        {
+          "url": "https://github.com/joinia/webray.com.cn/blob/main/Clinic's-Patient-Management-System/cpmssql.md",
+          "name": "https://github.com/joinia/webray.com.cn/blob/main/Clinic's-Patient-Management-System/cpmssql.md",
+          "tags": ["Exploit", "Third Party Advisory"],
+          "refsource": "MISC"
+        },
+        {
+          "url": "https://vuldb.com/?id.207854",
+          "name": "https://vuldb.com/?id.207854",
+          "tags": [],
+          "refsource": "MISC"
+        }
+      ]
+    },
+    "data_format": "MITRE",
+    "description": {
+      "description_data": [
+        {
+          "lang": "en",
+          "value": "A vulnerability was found in SourceCodester Clinics Patient Management System 1.0. It has been rated as critical. Affected by this issue is some unknown functionality of the file medicine_details.php. The manipulation of the argument medicine leads to sql injection. The attack may be launched remotely. The exploit has been disclosed to the public and may be used. VDB-207854 is the identifier assigned to this vulnerability."
+        }
+      ]
+    },
+    "problemtype": {
+      "problemtype_data": [
+        {
+          "description": []
+        }
+      ]
+    },
+    "data_version": "4.0",
+    "CVE_data_meta": {
+      "ID": "CVE-2022-3122",
+      "ASSIGNER": "cna@vuldb.com"
+    }
+  },
+  "impact": {},
+  "publishedDate": "2022-09-05T14:15Z",
+  "configurations": {
+    "nodes": [],
+    "CVE_data_version": "4.0"
+  },
+  "lastModifiedDate": "2022-09-06T09:00Z"
+}]


### PR DESCRIPTION
When processing modified references urls containing single quotes (line 41), the current extraction method will truncate the url, resulting in a "KeyError" (line 48) when using a dictionary to obtain data subsequently. For example, in the latest nvdcve-1.1-modified.json, for CVE-2022-1980, the reference link given is: [**https://github.com/Xor-Gerke/webray.com.cn/blob/main/cve/Product%20Show%20Room%20Site/'Telephone'%20Stored%20Cross-Site%20Scripting(XSS).md**],will cause the error mentioned above. I adjusted the url extraction method to fix it.