### PR TITLE
Remove class from login/register links

### DIFF
--- a/opencve/templates/base.html
+++ b/opencve/templates/base.html
@@ -71,10 +71,10 @@
                         </ul>
                     </li>
                     {% else %}
-                    <li class="hidden-xs">
+                    <li>
                         <a href="{{ url_for('user.login') }}">Sign in</a>
                     </li>
-                    <li class="hidden-xs">
+                    <li>
                         <a href="{{ url_for('user.register') }}">Register</a>
                     </li>
                     {% endif %}


### PR DESCRIPTION
Closes #213 

In this PR, the CSS classes are removed for the login and registration links, so that the links are also displayed on screens with small width. The available space is sufficient so that the class `hidden-xs` can be removed without the need for cosmetic realignment or redesign.