### PR TITLE
Dynamize/variablize app name und url

### DIFF
--- a/opencve/default.cfg
+++ b/opencve/default.cfg
@@ -1,4 +1,10 @@
 [core]
+; The name of the application as it should be displayed in the user interface
+app_name = OpenCVE
+
+; The URL of the application, how it should be referenced in the user interface
+app_url = http://opencve.io
+
 ; The name and the port of OpenCVE server. Change it if you launch the
 ; webserver with a different value (ie opencve webserver -b 0.0.0.0:80).
 server_name = 127.0.0.1:8000

--- a/opencve/default.cfg
+++ b/opencve/default.cfg
@@ -1,9 +1,12 @@
 [core]
-; The name of the application as it should be displayed in the user interface
+; Name of the application as it should be displayed in the user interface
 app_name = OpenCVE
 
-; The URL of the application, how it should be referenced in the user interface
+; URL of the application, how it should be referenced in the user interface
 app_url = http://opencve.io
+
+; Twitter user name
+app_twitter = opencve
 
 ; The name and the port of OpenCVE server. Change it if you launch the
 ; webserver with a different value (ie opencve webserver -b 0.0.0.0:80).

--- a/opencve/settings.py
+++ b/opencve/settings.py
@@ -36,6 +36,10 @@ from opencve.tasks import CELERYBEAT_SCHEDULE
 
 
 class Config(object):
+    APP_NAME = config.get("core", "app_name", fallback="OpenCVE.io")
+    APP_URL = config.get("core", "app_url", fallback="http://opencve.io")
+    APP_TWITTER = config.get("core", "app_url", fallback="opencve")
+
     SECRET_KEY = config.get("core", "secret_key")
     USE_REVERSE_PROXY = config.getboolean("core", "use_reverse_proxy", fallback=False)
 
@@ -86,7 +90,7 @@ class Config(object):
     REPORT_COUNT_EXCERPT = 3
 
     # Flask-User
-    USER_APP_NAME = "OpenCVE.io"
+    USER_APP_NAME = config.get("core", "user_app_name", fallback="OpenCVE.io")
     USER_ENABLE_CHANGE_USERNAME = False
     USER_ENABLE_MULTIPLE_EMAILS = True
     USER_AUTO_LOGIN_AFTER_CONFIRM = False

--- a/opencve/settings.py
+++ b/opencve/settings.py
@@ -36,7 +36,7 @@ from opencve.tasks import CELERYBEAT_SCHEDULE
 
 
 class Config(object):
-    APP_NAME = config.get("core", "app_name", fallback="OpenCVE.io")
+    APP_NAME = config.get("core", "app_name", fallback="OpenCVE")
     APP_URL = config.get("core", "app_url", fallback="http://opencve.io")
     APP_TWITTER = config.get("core", "app_url", fallback="opencve")
 

--- a/opencve/templates/_welcome/base_welcome.html
+++ b/opencve/templates/_welcome/base_welcome.html
@@ -8,7 +8,7 @@
           integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="{{ url_for('welcome.static', filename='css/style.css') }}">
 
-    <title>{% block title %}Welcome to OpenCVE{% endblock %}</title>
+    <title>{% block title %}Welcome to {{ config.APP_NAME }}{% endblock %}</title>
 </head>
 <body>
 

--- a/opencve/templates/_welcome/index.html
+++ b/opencve/templates/_welcome/index.html
@@ -7,7 +7,7 @@
 
     <div class="starter-template">
         <img src="{{ url_for('static', filename='img/logo_full_48.png') }}" alt="Logo">
-        <h1>Welcome to OpenCVE</h1>
+        <h1>Welcome to {{ config.APP_NAME }}</h1>
         <p class="lead">
             Start to explore the list of <a href="{{ url_for('main.cves') }}">CVE</a> or find it using <a
                 href="{{ url_for('main.vendors') }}">Vendors</a>.

--- a/opencve/templates/base.html
+++ b/opencve/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>{% block title %}OpenCVE{% endblock %}</title>
+    <title>{% block title %}{{ config.APP_NAME }}{% endblock %}</title>
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <link rel="shortcut icon" href="{{ url_for('static', filename='img/favicon.ico') }}">

--- a/opencve/templates/base_blank.html
+++ b/opencve/templates/base_blank.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>{% block title %}OpenCVE{% endblock %}</title>
+    <title>{% block title %}{{ config.APP_NAME }}{% endblock %}</title>
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
     <link rel="shortcut icon" href="{{ url_for('static', filename='img/favicon.ico') }}">
 

--- a/opencve/templates/change.html
+++ b/opencve/templates/change.html
@@ -7,7 +7,7 @@
 <section class="content-header">
     <h1><a class="btn btn-default" href="{{ url_for('main.cve', cve_id=change.cve.cve_id) }}"><i class="fa fa-arrow-left"></i></a> Change of {{ change.created_at.strftime('%d %b %Y, %H:%M') }} <small>{{ change.cve.cve_id }}</small></h1>
     <ol class="breadcrumb">
-        <li><a href="{{ url_for('main.home') }}">OpenCVE</a></li>
+        <li><a href="{{ url_for('main.home') }}">{{ config.APP_NAME }}</a></li>
         <li><a href="{{ url_for('main.cves') }}">Vulnerabilities (CVE)</a></li>
         <li><a href="{{ url_for('main.cve', cve_id=change.cve.cve_id) }}">{{ change.cve.cve_id }}</a></li>
         <li class="active">Change {{ change.created_at.strftime('%d %b %Y, %H:%M') }}</li>

--- a/opencve/templates/cve.html
+++ b/opencve/templates/cve.html
@@ -8,7 +8,7 @@
 <section class="content-header">
     <h1>{{ cve.cve_id }}</h1>
     <ol class="breadcrumb">
-        <li><a href="{{ url_for('main.home') }}">OpenCVE</a></li>
+        <li><a href="{{ url_for('main.home') }}">{{ config.APP_NAME }}</a></li>
         <li><a href="{{ url_for('main.cves') }}">Vulnerabilities (CVE)</a></li>
         <li class="active">{{ cve.cve_id }}</li>
     </ol>

--- a/opencve/templates/cves.html
+++ b/opencve/templates/cves.html
@@ -21,7 +21,7 @@ Vulnerabilities (CVE)
 <section class="content-header">
     <h1>Vulnerabilities (CVE)</h1>
     <ol class="breadcrumb">
-        <li><a href="{{ url_for('main.home') }}">OpenCVE</a></li>
+        <li><a href="{{ url_for('main.home') }}">{{ config.APP_NAME }}</a></li>
         <li class="active">Vulnerabilities (CVE)</li>
     </ol>
 </section>

--- a/opencve/templates/cwes.html
+++ b/opencve/templates/cwes.html
@@ -7,7 +7,7 @@
 <section class="content-header">
     <h1>Categories (CWE)</h1>
     <ol class="breadcrumb">
-        <li><a href="{{ url_for('main.home') }}">OpenCVE</a></li>
+        <li><a href="{{ url_for('main.home') }}">{{ config.APP_NAME }}</a></li>
         <li class="active">Categories (CWE)</li>
     </ol>
 </section>

--- a/opencve/templates/emails/report_message.html
+++ b/opencve/templates/emails/report_message.html
@@ -196,7 +196,7 @@ Respmail v1.1 (http://charlesmudy.com/respmail/)
                                                     <table border="0" cellpadding="20" cellspacing="0" width="100%">
                                                         <tr>
                                                             <td align="center">
-                                                                <img title="OpenCVE" alt="Text" style="max-width:100%;"
+                                                                <img title="{{ config.APP_NAME }}" alt="Text" style="max-width:100%;"
                                                                      class="flexibleImageSmall"
                                                                      src="{{ url_for('main.static', filename='img/mail_icon.png', _external=True) }}">
                                                             </td>
@@ -426,8 +426,8 @@ Respmail v1.1 (http://charlesmudy.com/respmail/)
                                                                             <div style="text-align:center;font-family:Helvetica,Arial,sans-serif;font-size:15px;margin-bottom:0;margin-top:3px;color:#5F5F5F;line-height:135%;">
                                                                                 <a style="color:#ffffff;"
                                                                                    target="_blank"
-                                                                                   href="https://twitter.com/opencve">Follow
-                                                                                    OpenCVE on Twitter</a></div>
+                                                                                   href="https://twitter.com/{{ config.APP_TWITTER }}">Follow
+                                                                                   {{ config.APP_NAME }} on Twitter</a></div>
                                                                         </td>
                                                                     </tr>
                                                                     </tbody>
@@ -485,9 +485,9 @@ Respmail v1.1 (http://charlesmudy.com/respmail/)
 
                                                                 <div style="font-family:Helvetica,Arial,sans-serif;font-size:13px;color:#828282;text-align:center;line-height:120%">
                                                                     <div>Copyright &#169; 2021 <a
-                                                                            href="https://opencve.io" target="_blank"
+                                                                            href="{{ config.APP_URL }}" target="_blank"
                                                                             style="text-decoration:none;color:#828282"><span
-                                                                            style="color:#828282">OpenCVE.io</span></a>.
+                                                                            style="color:#828282">{{ config.APP_NAME }}</span></a>.
                                                                         All&nbsp;rights&nbsp;reserved.
                                                                     </div>
                                                                     <div>If you do not want to receive emails, you can

--- a/opencve/templates/emails/report_message.txt
+++ b/opencve/templates/emails/report_message.txt
@@ -14,4 +14,4 @@ View the full report : {{ url_for('main.report', link=report_public_link, _exter
 
 If you do not want to receive emails, you can unsubscribe here : {{ url_for('main.notifications', _external=True, _scheme='https') }}
 
-OpenCVE - https://opencve.io
+{{ config.APP_NAME }} - {{ config.APP_URL }}

--- a/opencve/templates/flask_user/forgot_password.html
+++ b/opencve/templates/flask_user/forgot_password.html
@@ -9,7 +9,7 @@
     <div class="login-box-body">
         <div class="login-logo">
             <img src="{{ url_for('static', filename='img/logo_full_48.png') }}" alt="Logo">
-            <a href="{{ url_for('main.home') }}">OpenCVE.io</a>
+            <a href="{{ url_for('main.home') }}">{{ config.APP_NAME }}</a>
         </div>
         {% include 'flash_messages.html' %}
         <p class="login-box-msg"><strong>Enter your email address below to receive instructions on how to reset your

--- a/opencve/templates/flask_user/login.html
+++ b/opencve/templates/flask_user/login.html
@@ -10,7 +10,7 @@
     <div class="login-box-body">
         <div class="login-logo">
             <img src="{{ url_for('static', filename='img/logo_full_48.png') }}" alt="Logo">
-            <a href="{{ url_for('main.home') }}">OpenCVE.io</a>
+            <a href="{{ url_for('main.home') }}">{{ config.APP_NAME }}</a>
         </div>
         {% include 'flash_messages.html' %}
         <p class="login-box-msg"><strong>Sign in to your account</strong></p>

--- a/opencve/templates/flask_user/register.html
+++ b/opencve/templates/flask_user/register.html
@@ -1,6 +1,6 @@
 {% extends 'base_blank.html' %}
 
-{% block title %}Join OpenCVE - {{ super() }}{% endblock %}
+{% block title %}Join {{ config.APP_NAME }} - {{ super() }}{% endblock %}
 
 {% block content %}
 {% from "_macros.html" import render_field %}
@@ -11,7 +11,7 @@
     <div class="register-box-body">
         <div class="register-logo">
             <img src="{{ url_for('static', filename='img/logo_full_48.png') }}" alt="Logo">
-            <a href="{{ url_for('main.home') }}">OpenCVE.io</a>
+            <a href="{{ url_for('main.home') }}">{{ config.APP_NAME }}</a>
         </div>
         {% include 'flash_messages.html' %}
         <p class="login-box-msg"><strong>Register a new membership</strong></p>

--- a/opencve/templates/flask_user/resend_confirm_email.html
+++ b/opencve/templates/flask_user/resend_confirm_email.html
@@ -8,7 +8,7 @@
     <div class="login-box-body">
         <div class="login-logo">
             <img src="{{ url_for('static', filename='img/logo_full_48.png') }}" alt="Logo">
-            <a href="{{ url_for('main.home') }}">OpenCVE.io</a>
+            <a href="{{ url_for('main.home') }}">{{ config.APP_NAME }}</a>
         </div>
         {% include 'flash_messages.html' %}
         <p class="login-box-msg"><strong>Enter your email address below to receive a new confirmation link.</strong></p>

--- a/opencve/templates/home.html
+++ b/opencve/templates/home.html
@@ -9,7 +9,7 @@
         {% if current_user.settings['activities_view'] == 'subscriptions' %}<small class="label label-default"><i class="fa fa-filter"></i> subscriptions</small>{% endif %}
     </h1>
     <ol class="breadcrumb">
-        <li><a href="{{ url_for('main.home') }}">OpenCVE</a></li>
+        <li><a href="{{ url_for('main.home') }}">{{ config.APP_NAME }}</a></li>
         <li class="active">Dashboard</li>
     </ol>
 </section>

--- a/opencve/templates/report.html
+++ b/opencve/templates/report.html
@@ -11,7 +11,7 @@
         report.created_at.strftime("%D %H:%M") }}
     </h1>
     <ol class="breadcrumb">
-        <li><a href="{{ url_for('main.home') }}">OpenCVE</a></li>
+        <li><a href="{{ url_for('main.home') }}">{{ config.APP_NAME }}</a></li>
         <li><a href="{{ url_for('main.reports') }}">Reports</a></li>
         <li class="active">Report details</li>
     </ol>

--- a/opencve/templates/reports.html
+++ b/opencve/templates/reports.html
@@ -7,7 +7,7 @@
 <section class="content-header">
     <h1>Reports</h1>
     <ol class="breadcrumb">
-        <li><a href="{{ url_for('main.home') }}">OpenCVE</a></li>
+        <li><a href="{{ url_for('main.home') }}">{{ config.APP_NAME }}</a></li>
         <li class="active">Reports</li>
     </ol>
 </section>

--- a/opencve/templates/vendors.html
+++ b/opencve/templates/vendors.html
@@ -7,7 +7,7 @@
 <section class="content-header">
     <h1>Vendors & Products</h1>
     <ol class="breadcrumb">
-        <li><a href="{{ url_for('main.home') }}">OpenCVE</a></li>
+        <li><a href="{{ url_for('main.home') }}">{{ config.APP_NAME }}</a></li>
         <li class="active">Vendors & Products</li>
     </ol>
 </section>


### PR DESCRIPTION
With this PR, all static naming of the app name and the URL are dynamized via configuration variables. This results in a harmonized naming of these elements. The name can be adapted to internal designations via the configuration; the specification of the own URL in e-mails is also implemented with this, so that emails from an own instance are now directed to the URL of the own instance.

The PR changes the standard configuration by the variables APP_NAME, APP_URL, APP_TWITTER, USER_APP_NAME, which are set to the previous values of Opencve.io in the standard configuration.

The mentioned copyright is excluded from this PR.