### PR TITLE
Dev/ncrocfer/fix importlib

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-          python-version: [3.6, 3.7, 3.8]
+          python-version: [3.7, 3.8]
     services:
       postgres:
         image: postgres

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 <p align="center">
   <a href="https://github.com/opencve/opencve/actions?query=workflow%3ATests"><img alt="Tests" src="https://github.com/opencve/opencve/workflows/Tests/badge.svg"></a>
-  <a href="https://www.python.org/"><img alt="Python versions" src="https://img.shields.io/badge/python-3.6%2B-blue.svg"></a>
+  <a href="https://www.python.org/"><img alt="Python versions" src="https://img.shields.io/badge/python-3.7%2B-blue.svg"></a>
   <a href="https://github.com/python/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 
@@ -54,7 +54,7 @@ Read the [How It Works](https://docs.opencve.io/how-it-works/) guide to learn in
 
 ## Requirements
 
-OpenCVE works with **Python >=3.6**.
+OpenCVE works with **Python >=3.7**.
 
 It uses the JSONB feature for performance, so you will need a **PostgreSQL** instance to store the data (CVE, Users, Vendors, Products, Subscriptions, ...). Other engines are not supported.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ werkzeug==1.0.1
 itsdangerous==1.1.0
 markupSafe==1.1.1
 jinja2==2.11.3
+importlib-metadata==4.13.0
 
 # Required by WTForms (new bug?)
 # see: https://stackoverflow.com/questions/61356834/wtforms-install-email-validator-for-email-validation-support

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,9 @@ setup(
         "Environment :: Web Environment",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
     entry_points={"console_scripts": ["opencve=opencve.cli:cli"]},
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
- Python3.6 is deprecated for 9 months and no more security fix is provided (https://endoflife.date/python)
- This PR fix a bug in Celery when the `importlib-metadata` package is used in Python 7 (https://github.com/celery/celery/issues/7783)