### PR TITLE
fix: remove duplicates items when pagination is used

### DIFF
--- a/opencve/controllers/alerts.py
+++ b/opencve/controllers/alerts.py
@@ -7,7 +7,7 @@ from opencve.models.alerts import Alert
 
 class AlertController(BaseController):
     model = Alert
-    order = Alert.created_at.desc()
+    order = [Alert.created_at.desc()]
     per_page_param = "ALERTS_PER_PAGE"
     schema = {
         "user_id": {"type": str},

--- a/opencve/controllers/base.py
+++ b/opencve/controllers/base.py
@@ -43,7 +43,7 @@ class BaseController(object):
         args = cls.parse_args(args)
         query, metas = cls.build_query(args)
 
-        objects = query.order_by(cls.order).paginate(
+        objects = query.order_by(*cls.order).paginate(
             args.get(cls.page_parameter), app.config[cls.per_page_param], True
         )
 

--- a/opencve/controllers/cves.py
+++ b/opencve/controllers/cves.py
@@ -19,7 +19,7 @@ from opencve.models.cwe import Cwe
 
 class CveController(BaseController):
     model = Cve
-    order = Cve.updated_at.desc()
+    order = [Cve.updated_at.desc(), Cve.id.desc()]
     per_page_param = "CVES_PER_PAGE"
     schema = {
         "search": {"type": str},

--- a/opencve/controllers/cwes.py
+++ b/opencve/controllers/cwes.py
@@ -9,7 +9,7 @@ from opencve.models.cwe import Cwe
 
 class CweController(BaseController):
     model = Cwe
-    order = Cwe.cwe_id.desc()
+    order = [Cwe.cwe_id.desc()]
     per_page_param = "CWES_PER_PAGE"
     schema = {
         "search": {"type": str},

--- a/opencve/controllers/products.py
+++ b/opencve/controllers/products.py
@@ -8,7 +8,7 @@ from opencve.models.products import Product
 
 class ProductController(BaseController):
     model = Product
-    order = Product.name.asc()
+    order = [Product.name.asc()]
     per_page_param = "PRODUCTS_PER_PAGE"
     page_parameter = "product_page"
     schema = {

--- a/opencve/controllers/reports.py
+++ b/opencve/controllers/reports.py
@@ -8,7 +8,7 @@ from opencve.models.reports import Report
 
 class ReportController(BaseController):
     model = Report
-    order = Report.created_at.desc()
+    order = [Report.created_at.desc()]
     per_page_param = "REPORTS_PER_PAGE"
     schema = {
         "user_id": {"type": str},

--- a/opencve/controllers/tags.py
+++ b/opencve/controllers/tags.py
@@ -8,7 +8,7 @@ from opencve.models.tags import UserTag
 
 class UserTagController(BaseController):
     model = UserTag
-    order = UserTag.name.asc()
+    order = [UserTag.name.asc()]
     per_page_param = "TAGS_PER_PAGE"
     schema = {
         "user_id": {"type": str},

--- a/opencve/controllers/vendors.py
+++ b/opencve/controllers/vendors.py
@@ -6,7 +6,7 @@ from opencve.models.vendors import Vendor
 
 class VendorController(BaseController):
     model = Vendor
-    order = Vendor.name.asc()
+    order = [Vendor.name.asc()]
     per_page_param = "VENDORS_PER_PAGE"
     schema = {
         "search": {"type": str},

--- a/tests/controllers/test_base.py
+++ b/tests/controllers/test_base.py
@@ -9,7 +9,7 @@ from opencve.models.cve import Cve
 
 class TestController(BaseController):
     model = Cve
-    order = Cve.created_at.desc()
+    order = [Cve.created_at.desc()]
     per_page_param = "CVES_PER_PAGE"
     schema = {
         "str": {"type": str, "default": "foobar"},


### PR DESCRIPTION
This PR fixes #237.

Duplicates are shown due to a pagination issue:

- when the NVD updates some CVEs the `lastModifiedDate` may be the same
- OpenCVE saves this information in the `updated_at` field
- so some CVEs have the same `updated_at` value, raising this issue when pagination is used

Ordering the CVEs by updated_at and CVE ID fixes it.