### PR TITLE
Vulnerability filter

### DIFF
--- a/opencve/checks/cpes.py
+++ b/opencve/checks/cpes.py
@@ -21,9 +21,9 @@ class Cpes(BaseCheck):
         # The CPEs list has been modified
         if payload["added"] or payload["removed"]:
 
-            # Change the CVE's vendors attribute
+            # Change the CVE's vendors attribute and mark vulnerable vendors/products
             self.cve_obj.vendors = flatten_vendors(
-                convert_cpes(self.cve_json["configurations"])
+                convert_cpes(self.cve_json["configurations"], True)
             )
             db.session.commit()
 

--- a/opencve/commands/imports/cve.py
+++ b/opencve/commands/imports/cve.py
@@ -7,6 +7,7 @@ import requests
 
 from opencve.commands import header, info, timed_operation
 from opencve.commands.imports.cpe import get_slug
+from opencve.constants import VULNERABLE_SEPARATOR
 from opencve.extensions import db
 from opencve.utils import convert_cpes, flatten_vendors, get_cwes
 from opencve.models import get_uuid
@@ -67,7 +68,7 @@ def run():
                 cwes = get_cwes(
                     item["cve"]["problemtype"]["problemtype_data"][0]["description"]
                 )
-                cpes = convert_cpes(item["configurations"])
+                cpes = convert_cpes(item["configurations"], True)
                 vendors = flatten_vendors(cpes)
 
                 # Create the CVEs mappings
@@ -88,7 +89,9 @@ def run():
 
                 # Create the vendors and their products
                 for vendor, products in cpes.items():
-
+                    # Skips duplicates, which identify vulnerable parts of configuration
+                    if VULNERABLE_SEPARATOR in vendor:
+                        continue
                     # Create the vendor
                     if vendor not in mappings["vendors"].keys():
                         mappings["vendors"][vendor] = dict(id=get_uuid(), name=vendor)

--- a/opencve/commands/utils.py
+++ b/opencve/commands/utils.py
@@ -66,7 +66,7 @@ class CveUtil(object):
         cwes = get_cwes(
             cve_json["cve"]["problemtype"]["problemtype_data"][0]["description"]
         )
-        cpes = convert_cpes(cve_json["configurations"])
+        cpes = convert_cpes(cve_json["configurations"], True)
         vendors = flatten_vendors(cpes)
 
         # Create the CVE

--- a/opencve/constants.py
+++ b/opencve/constants.py
@@ -30,7 +30,7 @@ CVSS_SCORES = [
 
 PRODUCT_SEPARATOR = "$PRODUCT$"
 
-VULNERABLE_SEPARATOR = '$VULN$'
+VULNERABLE_SEPARATOR = "$VULN$"
 
 # This is the message sent by Flask-User in the `flash` function
 EMAIL_CONFIRMATION_MESSAGE = (

--- a/opencve/constants.py
+++ b/opencve/constants.py
@@ -30,6 +30,8 @@ CVSS_SCORES = [
 
 PRODUCT_SEPARATOR = "$PRODUCT$"
 
+VULNERABLE_SEPARATOR = '$VULN$'
+
 # This is the message sent by Flask-User in the `flash` function
 EMAIL_CONFIRMATION_MESSAGE = (
     "Your email address has not yet been confirmed. Check your email Inbox "

--- a/opencve/context.py
+++ b/opencve/context.py
@@ -2,7 +2,7 @@ from flask import current_app as app
 from flask import request, url_for
 from flask_user import current_user
 
-from opencve.constants import EVENT_TYPES, PRODUCT_SEPARATOR
+from opencve.constants import EVENT_TYPES, PRODUCT_SEPARATOR, VULNERABLE_SEPARATOR
 from opencve.models.tags import UserTag
 
 
@@ -99,9 +99,9 @@ def _excerpt(objects, _type):
 
     # Keep the objects of the requested type
     if _type == "products":
-        objects = [o for o in objects if PRODUCT_SEPARATOR in o]
+        objects = [o for o in objects if PRODUCT_SEPARATOR in o and VULNERABLE_SEPARATOR not in o]
     else:
-        objects = [o for o in objects if not PRODUCT_SEPARATOR in o]
+        objects = [o for o in objects if not PRODUCT_SEPARATOR in o and VULNERABLE_SEPARATOR not in o]
 
     objects = sorted(objects)
     output += '<span class="badge badge-primary">{}</span> '.format(len(objects))

--- a/opencve/context.py
+++ b/opencve/context.py
@@ -99,9 +99,17 @@ def _excerpt(objects, _type):
 
     # Keep the objects of the requested type
     if _type == "products":
-        objects = [o for o in objects if PRODUCT_SEPARATOR in o and VULNERABLE_SEPARATOR not in o]
+        objects = [
+            o
+            for o in objects
+            if PRODUCT_SEPARATOR in o and VULNERABLE_SEPARATOR not in o
+        ]
     else:
-        objects = [o for o in objects if not PRODUCT_SEPARATOR in o and VULNERABLE_SEPARATOR not in o]
+        objects = [
+            o
+            for o in objects
+            if PRODUCT_SEPARATOR not in o and VULNERABLE_SEPARATOR not in o
+        ]
 
     objects = sorted(objects)
     output += '<span class="badge badge-primary">{}</span> '.format(len(objects))

--- a/opencve/controllers/home.py
+++ b/opencve/controllers/home.py
@@ -5,7 +5,7 @@ from sqlalchemy import and_
 from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.orm import joinedload, aliased
 
-from opencve.constants import PRODUCT_SEPARATOR
+from opencve.constants import PRODUCT_SEPARATOR, VULNERABLE_SEPARATOR
 from opencve.controllers.main import main, welcome
 from opencve.controllers.reports import ReportController
 from opencve.extensions import db
@@ -78,6 +78,19 @@ def home():
         vendors.extend(
             [
                 f"{p.vendor.name}{PRODUCT_SEPARATOR}{p.name}"
+                for p in current_user.products
+            ]
+        )
+        if not vendors:
+            vendors = [None]
+        query = query.filter(Cve.vendors.has_any(array(vendors)))
+
+    # Filter by vulnerable subscriptions
+    if current_user.settings["activities_view"] == "vulnerable":
+        vendors = [VULNERABLE_SEPARATOR + v.name for v in current_user.vendors]
+        vendors.extend(
+            [
+                f"{VULNERABLE_SEPARATOR}{p.vendor.name}{PRODUCT_SEPARATOR}{p.name}"
                 for p in current_user.products
             ]
         )

--- a/opencve/forms.py
+++ b/opencve/forms.py
@@ -122,7 +122,7 @@ class ActivitiesViewForm(FlaskForm):
             ("subscriptions", "Display subscriptions activities"),
             (
                 "vulnerable",
-                "Display activities with subscriptions as source of vulnerability"
+                "Display activities with subscriptions as source of vulnerability",
             ),
         ],
     )

--- a/opencve/forms.py
+++ b/opencve/forms.py
@@ -79,6 +79,7 @@ class MailNotificationsForm(FlaskForm):
 class FiltersNotificationForm(FlaskForm):
     new_cve = BooleanField("New CVE")
     first_time = BooleanField("Subscription appeared for the first time")
+    vulnerable = BooleanField("Subscription appeared as vulnerable")
     references = BooleanField("Reference changed")
     cvss = BooleanField("CVSS changed")
     cpes = BooleanField("CPE changed")
@@ -119,5 +120,6 @@ class ActivitiesViewForm(FlaskForm):
         choices=[
             ("all", "Display all activities"),
             ("subscriptions", "Display subscriptions activities"),
+            ("vulnerable", "Display activities with subscriptions as source of vulnerability"),
         ],
     )

--- a/opencve/forms.py
+++ b/opencve/forms.py
@@ -120,6 +120,9 @@ class ActivitiesViewForm(FlaskForm):
         choices=[
             ("all", "Display all activities"),
             ("subscriptions", "Display subscriptions activities"),
-            ("vulnerable", "Display activities with subscriptions as source of vulnerability"),
+            (
+                "vulnerable",
+                "Display activities with subscriptions as source of vulnerability"
+            ),
         ],
     )

--- a/opencve/models/users.py
+++ b/opencve/models/users.py
@@ -14,6 +14,7 @@ def get_default_filters():
         "event_types": [
             "new_cve",
             "first_time",
+            "vulnerable",
             "references",
             "cvss",
             "cpes",

--- a/opencve/tasks/alerts.py
+++ b/opencve/tasks/alerts.py
@@ -78,16 +78,16 @@ def handle_alerts():
                         users[user] = {"products": [], "vendors": []}
                     # User only wants notification for alerts where subscriptions are marked as vulnerable
                     if (
-                            "vulnerable" in user.filters_notifications
-                            and VULNERABLE_SEPARATOR in product.name
+                        "vulnerable" in user.filters_notifications
+                        and VULNERABLE_SEPARATOR in product.name
                     ):
                         users[user]["products"].append(
                             product.name.replace(VULNERABLE_SEPARATOR, "")
                         )
                     # User wants all notifications for subscriptions independent independent of vulnerability
                     elif (
-                            "vulnerable" not in user.filters_notifications
-                            and VULNERABLE_SEPARATOR not in product.name
+                        "vulnerable" not in user.filters_notifications
+                        and VULNERABLE_SEPARATOR not in product.name
                     ):
                         users[user]["products"].append(product.name)
             # Vendor

--- a/opencve/tasks/alerts.py
+++ b/opencve/tasks/alerts.py
@@ -77,10 +77,18 @@ def handle_alerts():
                     if user not in users.keys():
                         users[user] = {"products": [], "vendors": []}
                     # User only wants notification for alerts where subscriptions are marked as vulnerable
-                    if "vulnerable" in user.filters_notifications and VULNERABLE_SEPARATOR in product.name:
-                        users[user]["products"].append(product.name.replace(VULNERABLE_SEPARATOR, ""))
+                    if (
+                            "vulnerable" in user.filters_notifications
+                            and VULNERABLE_SEPARATOR in product.name
+                    ):
+                        users[user]["products"].append(
+                            product.name.replace(VULNERABLE_SEPARATOR, "")
+                        )
                     # User wants all notifications for subscriptions independent independent of vulnerability
-                    elif "vulnerable" not in user.filters_notifications and VULNERABLE_SEPARATOR not in product.name:
+                    elif (
+                            "vulnerable" not in user.filters_notifications
+                            and VULNERABLE_SEPARATOR not in product.name
+                    ):
                         users[user]["products"].append(product.name)
             # Vendor
             else:

--- a/opencve/tasks/alerts.py
+++ b/opencve/tasks/alerts.py
@@ -1,6 +1,6 @@
 from celery.utils.log import get_task_logger
 
-from opencve.constants import PRODUCT_SEPARATOR
+from opencve.constants import PRODUCT_SEPARATOR, VULNERABLE_SEPARATOR
 from opencve.extensions import cel, db
 from opencve.models.alerts import Alert
 from opencve.models.cve import Cve
@@ -64,17 +64,30 @@ def handle_alerts():
                 vendor = Vendor.query.filter_by(
                     name=v.split(PRODUCT_SEPARATOR)[0]
                 ).first()
+                # Skip if vendor is duplicate for vulnerability identification
+                if vendor is None:
+                    continue
                 product = Product.query.filter_by(
                     name=v.split(PRODUCT_SEPARATOR)[1], vendor_id=vendor.id
                 ).first()
+                # Skip if product is duplicate for vulnerability identification
+                if product is None:
+                    continue
                 for user in product.users:
                     if user not in users.keys():
                         users[user] = {"products": [], "vendors": []}
-                    users[user]["products"].append(product.name)
-
+                    # User only wants notification for alerts where subscriptions are marked as vulnerable
+                    if "vulnerable" in user.filters_notifications and VULNERABLE_SEPARATOR in product.name:
+                        users[user]["products"].append(product.name.replace(VULNERABLE_SEPARATOR, ""))
+                    # User wants all notifications for subscriptions independent independent of vulnerability
+                    elif "vulnerable" not in user.filters_notifications and VULNERABLE_SEPARATOR not in product.name:
+                        users[user]["products"].append(product.name)
             # Vendor
             else:
                 vendor = Vendor.query.filter_by(name=v).first()
+                # Skip if v is duplicate of vendor to identify vulnerability
+                if vendor is None:
+                    continue
                 for user in vendor.users:
                     if user not in users.keys():
                         users[user] = {"products": [], "vendors": []}

--- a/opencve/templates/profiles/notifications.html
+++ b/opencve/templates/profiles/notifications.html
@@ -30,6 +30,12 @@
                                 one of your subscriptions appears for the first time in an existing CVE
                             </label>
                         </div>
+                        <div class="checkbox">
+                            <label>
+                                {{ filters_notifications_form.vulnerable() }}
+                                your subscription is marked as source of vulnerability in CVE
+                            </label>
+                        </div>
                     </div>
 
                     <div class="form-group">

--- a/opencve/utils.py
+++ b/opencve/utils.py
@@ -13,7 +13,9 @@ def convert_cpes(conf, mark_vulnerable=False):
     cpes = {}
     # CPE-conversion with duplicates for vulnerability-identification
     if mark_vulnerable:
-        matches = nested_lookup("cpe_match", conf) if not isinstance(conf, list) else conf
+        matches = (
+            nested_lookup("cpe_match", conf) if not isinstance(conf, list) else conf
+        )
         for match in matches:
             for cpe in match:
                 if "cpe23Uri" not in cpe:
@@ -24,8 +26,10 @@ def convert_cpes(conf, mark_vulnerable=False):
                 # If CPE is marked as vulnerable create a duplicate with string to identify vulnerability
                 if cpe["vulnerable"]:
                     if VULNERABLE_SEPARATOR + vendor_product[0] not in cpes:
-                        cpes[VULNERABLE_SEPARATOR+vendor_product[0]] = []
-                    cpes[VULNERABLE_SEPARATOR+vendor_product[0]].append(vendor_product[1])
+                        cpes[VULNERABLE_SEPARATOR + vendor_product[0]] = []
+                    cpes[VULNERABLE_SEPARATOR + vendor_product[0]].append(
+                        vendor_product[1]
+                    )
                 # Insert regular CPE information
                 cpes[vendor_product[0]].append(vendor_product[1])
 

--- a/opencve/utils.py
+++ b/opencve/utils.py
@@ -22,17 +22,18 @@ def convert_cpes(conf, mark_vulnerable=False):
                     continue
                 vendor_product = cpe["cpe23Uri"].split(":")[3:5]
                 if vendor_product[0] not in cpes:
-                    cpes[vendor_product[0]] = []
+                    cpes[vendor_product[0]] = set()
                 # If CPE is marked as vulnerable create a duplicate with string to identify vulnerability
                 if cpe["vulnerable"]:
                     if VULNERABLE_SEPARATOR + vendor_product[0] not in cpes:
-                        cpes[VULNERABLE_SEPARATOR + vendor_product[0]] = []
-                    cpes[VULNERABLE_SEPARATOR + vendor_product[0]].append(
+                        cpes[VULNERABLE_SEPARATOR + vendor_product[0]] = set()
+                    cpes[VULNERABLE_SEPARATOR + vendor_product[0]].add(
                         vendor_product[1]
                     )
                 # Insert regular CPE information
-                cpes[vendor_product[0]].append(vendor_product[1])
-
+                cpes[vendor_product[0]].add(vendor_product[1])
+        for vendor in cpes:
+            cpes[vendor] = list(cpes[vendor])
     else:
         # Standard CPE-conversion
         uris = nested_lookup("cpe23Uri", conf) if not isinstance(conf, list) else conf

--- a/opencve/views/profile.py
+++ b/opencve/views/profile.py
@@ -36,6 +36,7 @@ def notifications():
         obj=current_user,
         new_cve=True if "new_cve" in filters["event_types"] else False,
         first_time=True if "first_time" in filters["event_types"] else False,
+        vulnerable=True if "vulnerable" in filters["event_types"] else False,
         references=True if "references" in filters["event_types"] else False,
         cvss=True if "cvss" in filters["event_types"] else False,
         cpes=True if "cpes" in filters["event_types"] else False,
@@ -76,6 +77,7 @@ def notifications():
             for typ in [
                 "new_cve",
                 "first_time",
+                "vulnerable",
                 "references",
                 "cvss",
                 "cpes",

--- a/tests/checks/test_cpes.py
+++ b/tests/checks/test_cpes.py
@@ -37,6 +37,10 @@ def test_check_cpes(create_cve, handle_events, open_file):
     cve = Cve.query.filter_by(cve_id="CVE-2018-18074").first()
     assert sorted(cve.vendors) == sorted(
         [
+            f"{VULNERABLE_SEPARATOR}canonical",
+            f"{VULNERABLE_SEPARATOR}canonical{PRODUCT_SEPARATOR}ubuntu_linux",
+            f"{VULNERABLE_SEPARATOR}opencveio",
+            f"{VULNERABLE_SEPARATOR}opencveio{PRODUCT_SEPARATOR}opencve",
             "canonical",
             f"canonical{PRODUCT_SEPARATOR}ubuntu_linux",
             "opencveio",

--- a/tests/checks/test_cpes.py
+++ b/tests/checks/test_cpes.py
@@ -1,4 +1,4 @@
-from opencve.constants import PRODUCT_SEPARATOR
+from opencve.constants import PRODUCT_SEPARATOR, VULNERABLE_SEPARATOR
 from opencve.models.cve import Cve
 from opencve.models.changes import Change
 from opencve.models.events import Event
@@ -12,6 +12,10 @@ def test_check_cpes(create_cve, handle_events, open_file):
     cve = create_cve("CVE-2018-18074")
     assert sorted(cve.vendors) == sorted(
         [
+            f"{VULNERABLE_SEPARATOR}python-requests",
+            f"{VULNERABLE_SEPARATOR}python-requests{PRODUCT_SEPARATOR}requests",
+            f"{VULNERABLE_SEPARATOR}canonical",
+            f"{VULNERABLE_SEPARATOR}canonical{PRODUCT_SEPARATOR}ubuntu_linux",
             "python-requests",
             f"python-requests{PRODUCT_SEPARATOR}requests",
             "canonical",

--- a/tests/commands/test_utils.py
+++ b/tests/commands/test_utils.py
@@ -1,7 +1,7 @@
 import datetime
 
 from opencve.commands.utils import CveUtil
-from opencve.constants import PRODUCT_SEPARATOR
+from opencve.constants import PRODUCT_SEPARATOR, VULNERABLE_SEPARATOR
 from opencve.extensions import db
 from opencve.models.changes import Change
 from opencve.models.cve import Cve
@@ -24,6 +24,10 @@ def test_create_cve(app, open_file):
     assert cve.cwes == ["CWE-116"]
     assert sorted(cve.vendors) == sorted(
         [
+            f"{VULNERABLE_SEPARATOR}fedoraproject",
+            f"{VULNERABLE_SEPARATOR}fedoraproject{PRODUCT_SEPARATOR}fedora",
+            f"{VULNERABLE_SEPARATOR}python",
+            f"{VULNERABLE_SEPARATOR}python{PRODUCT_SEPARATOR}python",
             "fedoraproject",
             f"fedoraproject{PRODUCT_SEPARATOR}fedora",
             "python",


### PR DESCRIPTION
fixes #184

This is the improvement of #232 

This pull request contains following improvements:

- The CVE gets a list of vulnerable vendors/products
- The users can decide if they would like to get all activities in CVE, where their subscriptions are referenced or only the ones, where the subscriptions are marked as source of vulnerability
- The dashboard offers a view, where only the activities are listed of subscriptions that are marked as source of vulnerability in a CVE

This approach is designed to work without changes of the database, but this would result in the identification of vulnerable vendors/products for changed or new CVEs.
-> If possible, the `opencve import-data` command should be used to guaranty completeness of the data.  

This approach uses does not change the functionality of the current System, only enhances it. The solution of the identification of sources of vulnerabilities are solved by creating duplicates with identifiers for the vulnerability. With the example proposed in  [this comment](https://github.com/opencve/opencve/pull/232#issuecomment-1273398393), the resulting vendors object would look like:

['lexmark', 
'$VULN$lexmark', 
'lexmark$PRODUCT$b2236_firmware', 
'$VULN$lexmark$PRODUCT$b2236_firmware',
'lexmark$PRODUCT$b2236']

In the processing and the creation of vendors and products, the ones with the '$VULN$' Separator get ignored, so that no further vendors and products get created and the CVE entries can be filtered by the source of vulnerability.