### PR TITLE
 Improved Configuration Display

### DIFF
--- a/opencve/templates/cve.html
+++ b/opencve/templates/cve.html
@@ -128,7 +128,20 @@
                                         {% if loop.index == 1 and child.cpe_match|length > 1 %}
                                         <td class="col-md-1 rowspaned" rowspan="{{ child.cpe_match|length }}">OR</td>
                                         {% endif %}
-                                        <td>{{ cpe.cpe23Uri }}</td>
+                                                                                <td colspan="{{ 5 - ('versionStartIncluding' in cpe or 'versionStartExcluding' in cpe) - ('versionEndIncluding' in cpe or 'versionEndExcluding' in cpe)   }}">{{ cpe.cpe23Uri }}</td>
+                                        {% if cpe.versionStartIncluding %}
+                                            <td>From including<br>{{ cpe.versionStartIncluding }}</td>
+                                        {% elif cpe.versionStartExcluding %}
+                                            <td>From excluding<br>{{ cpe.versionStartExcluding }}</td>
+                                        {% endif %}
+                                        {% if cpe.versionEndIncluding %}
+                                            <td>Up to including<br>{{ cpe.versionEndIncluding }}</td>
+                                        {% elif cpe.versionEndExcluding %}
+                                            <td>Up to excluding<br>{{ cpe.versionEndExcluding }}</td>
+                                        {% endif %}
+                                        {% if cpe.vulnerable %}
+                                            <td class="col-md-1 rowspaned" rowspan="1">Vulnerable</td>
+                                        {% endif %}
                                     </tr>
                                     {% endfor %}
                                 </table>


### PR DESCRIPTION
fixes #180 and to some degree #204

This is an proposal of a solution for following issues:

- Display of version intervals - Some CPEs have attributes like "versionStartIncluding" or "versionEndExcluding", that indicate which versions of the product are meant
- Display of vulnerable component - All CPEs have an attribute "vulnerable", that indicates if they are the source of the vulnerability or only part of the configuration, which enables the vulnerability


Currently only the CPE-Strings are displayed (Example [CVE-2022-0019](https://www.opencve.io/cve/CVE-2022-0019))
![grafik](https://user-images.githubusercontent.com/99090817/225402009-1cfc61c0-72f8-45b6-a204-ad72786b781f.png)


This solution would be the proposed solution, that integrates both into the display of the Configurations.
![grafik](https://user-images.githubusercontent.com/99090817/225401877-f1b26802-f6e7-429b-83d1-d81026e4dd64.png)