### PR TITLE
fix: upgrade jsmin package to fix a dependency issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ celery==4.3.0
 cpe==1.2.1
 untangle==1.1.1
 cssmin==0.2.0
-jsmin==2.2.2
+jsmin==3.0.1
 requests==2.23.0
 nested-lookup==0.2.18
 deepdiff==4.0.7


### PR DESCRIPTION
Thanks to @TexGG who found the solution, here is a patch to fix the following issue:

- https://github.com/opencve/opencve/issues/239
- https://github.com/opencve/opencve/issues/277
- https://github.com/opencve/opencve/issues/198
