### PR TITLE
Issue #240 route to subscribe to vendors

### DIFF
--- a/opencve/api/__init__.py
+++ b/opencve/api/__init__.py
@@ -16,7 +16,7 @@ from opencve.api.vendors import VendorListResource, VendorResource, VendorCveRes
 from opencve.api.subscriptions import (
     SubscriptionListRessourceVendor,
     SubscriptionListRessourceProduct,
-    SubscriptionAddVendor
+    SubscriptionAddVendor,
 )
 
 

--- a/opencve/api/__init__.py
+++ b/opencve/api/__init__.py
@@ -16,6 +16,7 @@ from opencve.api.vendors import VendorListResource, VendorResource, VendorCveRes
 from opencve.api.subscriptions import (
     SubscriptionListRessourceVendor,
     SubscriptionListRessourceProduct,
+    SubscriptionAddVendor
 )
 
 
@@ -31,6 +32,7 @@ api.add_resource(CveListResource, "/cve")
 api.add_resource(CveResource, "/cve/<string:id>")
 api.add_resource(ReportListResource, "/reports")
 api.add_resource(SubscriptionListRessourceVendor, "/account/subscriptions/vendors")
+api.add_resource(SubscriptionAddVendor, "/account/subscriptions/vendor/add")
 api.add_resource(SubscriptionListRessourceProduct, "/account/subscriptions/products")
 api.add_resource(ReportResource, "/reports/<string:link>")
 api.add_resource(AlertListResource, "/reports/<string:link>/alerts")

--- a/opencve/api/subscriptions.py
+++ b/opencve/api/subscriptions.py
@@ -1,14 +1,17 @@
 from flask import request
-from flask_restful import fields, marshal_with
+from flask_restful import fields, marshal_with, reqparse
 
 from opencve.api.base import BaseResource
 from opencve.api.fields import HumanizedNameField
 from opencve.models.users import User
-
+from opencve.models.vendors import Vendor
+from opencve.extensions import db
+from opencve.models import is_valid_uuid
 
 vendor_list_fields = {
     "name": fields.String(attribute="name"),
     "human_name": HumanizedNameField(attribute="name"),
+    "vendor_id": fields.String(attribute="id")
 }
 
 product_list_fields = {
@@ -34,3 +37,19 @@ class SubscriptionListRessourceProduct(BaseResource):
             username=request.authorization.get("username")
         ).first()
         return user.products
+
+class SubscriptionAddVendor(BaseResource):
+    def post(self,):
+        user = User.query.filter_by(
+            username=request.authorization.get("username")
+        ).first()
+        vendor_id = request.form.get("id")
+        if not is_valid_uuid(vendor_id):
+            return {"status": "fail"}, 400
+        vendor = Vendor.query.filter_by(id=vendor_id).first()
+        if not vendor:
+            return {"status": "fail"}, 400
+        if vendor not in user.vendors:
+            user.vendors.append(vendor)
+            db.session.commit()
+            return {"status": "ok"}, 200

--- a/opencve/api/subscriptions.py
+++ b/opencve/api/subscriptions.py
@@ -11,7 +11,7 @@ from opencve.models import is_valid_uuid
 vendor_list_fields = {
     "name": fields.String(attribute="name"),
     "human_name": HumanizedNameField(attribute="name"),
-    "vendor_id": fields.String(attribute="id")
+    "vendor_id": fields.String(attribute="id"),
 }
 
 product_list_fields = {
@@ -38,8 +38,11 @@ class SubscriptionListRessourceProduct(BaseResource):
         ).first()
         return user.products
 
+
 class SubscriptionAddVendor(BaseResource):
-    def post(self,):
+    def post(
+        self,
+    ):
         user = User.query.filter_by(
             username=request.authorization.get("username")
         ).first()

--- a/opencve/api/vendors.py
+++ b/opencve/api/vendors.py
@@ -11,6 +11,7 @@ from opencve.controllers.vendors import VendorController
 vendor_list_fields = {
     "name": fields.String(attribute="name"),
     "human_name": HumanizedNameField(attribute="name"),
+    "vendor_id": fields.String(attribute="id")
 }
 
 vendor_fields = dict(

--- a/opencve/api/vendors.py
+++ b/opencve/api/vendors.py
@@ -11,7 +11,7 @@ from opencve.controllers.vendors import VendorController
 vendor_list_fields = {
     "name": fields.String(attribute="name"),
     "human_name": HumanizedNameField(attribute="name"),
-    "vendor_id": fields.String(attribute="id")
+    "vendor_id": fields.String(attribute="id"),
 }
 
 vendor_fields = dict(

--- a/tests/api/test_subscriptions.py
+++ b/tests/api/test_subscriptions.py
@@ -28,12 +28,13 @@ def test_list_vendors_subscriptions(client, create_user, handle_events):
     assert response.json == []
 
     handle_events("modified_cves/CVE-2018-18074.json")
-    user.vendors.append(Vendor.query.filter_by(name="canonical").first())
+    vendor = Vendor.query.filter_by(name="canonical").first()
+    user.vendors.append(vendor)
     db.session.commit()
 
     response = client.login("opencve").get("/api/account/subscriptions/vendors")
     assert response.status_code == 200
-    assert response.json == [{"human_name": "Canonical", "name": "canonical"}]
+    assert response.json == [{"human_name": "Canonical", "name": "canonical", "vendor_id": str(vendor.id)}]
 
 
 def test_list_products_subscriptions(client, create_user, handle_events):
@@ -55,3 +56,24 @@ def test_list_products_subscriptions(client, create_user, handle_events):
             "parent_vendor": "python-requests",
         }
     ]
+
+def test_add_vendor_subscription(client, create_user, create_vendor):
+    create_vendor("vendor1")
+    vendor_id = str(Vendor.query.filter_by(name="vendor1").first().id)
+    create_user("opencve")
+    
+    response = client.login("opencve").post("/api/account/subscriptions/vendor/add", data={"id": "fail"})
+    assert response.json == {'status': 'fail'}
+    assert response.status_code == 400
+    
+    response = client.login("opencve").post("/api/account/subscriptions/vendor/add", data={"id": f"{vendor_id[:-1]}a"})
+    assert response.json == {'status': 'fail'}
+    assert response.status_code == 400
+
+    response = client.login("opencve").post("/api/account/subscriptions/vendor/add", data={"id": vendor_id})
+    assert response.json == {"status": "ok"}
+    assert response.status_code == 200
+
+    response = client.login("opencve").get("/api/account/subscriptions/vendors")
+    assert response.status_code == 200
+    assert response.json == [{"human_name": "Vendor1", "name": "vendor1", "vendor_id": vendor_id}]

--- a/tests/api/test_subscriptions.py
+++ b/tests/api/test_subscriptions.py
@@ -34,7 +34,9 @@ def test_list_vendors_subscriptions(client, create_user, handle_events):
 
     response = client.login("opencve").get("/api/account/subscriptions/vendors")
     assert response.status_code == 200
-    assert response.json == [{"human_name": "Canonical", "name": "canonical", "vendor_id": str(vendor.id)}]
+    assert response.json == [
+        {"human_name": "Canonical", "name": "canonical", "vendor_id": str(vendor.id)}
+    ]
 
 
 def test_list_products_subscriptions(client, create_user, handle_events):
@@ -57,23 +59,32 @@ def test_list_products_subscriptions(client, create_user, handle_events):
         }
     ]
 
+
 def test_add_vendor_subscription(client, create_user, create_vendor):
     create_vendor("vendor1")
     vendor_id = str(Vendor.query.filter_by(name="vendor1").first().id)
     create_user("opencve")
-    
-    response = client.login("opencve").post("/api/account/subscriptions/vendor/add", data={"id": "fail"})
-    assert response.json == {'status': 'fail'}
-    assert response.status_code == 400
-    
-    response = client.login("opencve").post("/api/account/subscriptions/vendor/add", data={"id": f"{vendor_id[:-1]}a"})
-    assert response.json == {'status': 'fail'}
+
+    response = client.login("opencve").post(
+        "/api/account/subscriptions/vendor/add", data={"id": "fail"}
+    )
+    assert response.json == {"status": "fail"}
     assert response.status_code == 400
 
-    response = client.login("opencve").post("/api/account/subscriptions/vendor/add", data={"id": vendor_id})
+    response = client.login("opencve").post(
+        "/api/account/subscriptions/vendor/add", data={"id": f"{vendor_id[:-1]}a"}
+    )
+    assert response.json == {"status": "fail"}
+    assert response.status_code == 400
+
+    response = client.login("opencve").post(
+        "/api/account/subscriptions/vendor/add", data={"id": vendor_id}
+    )
     assert response.json == {"status": "ok"}
     assert response.status_code == 200
 
     response = client.login("opencve").get("/api/account/subscriptions/vendors")
     assert response.status_code == 200
-    assert response.json == [{"human_name": "Vendor1", "name": "vendor1", "vendor_id": vendor_id}]
+    assert response.json == [
+        {"human_name": "Vendor1", "name": "vendor1", "vendor_id": vendor_id}
+    ]

--- a/tests/api/test_vendors.py
+++ b/tests/api/test_vendors.py
@@ -1,5 +1,6 @@
 from opencve.models.vendors import Vendor
 
+
 def test_list_vendors_authentication(client, create_user):
     create_user("opencve")
     response = client.get("/api/vendors")
@@ -21,7 +22,11 @@ def test_list_vendors(client, create_user, create_vendor):
     vendor_id = str(Vendor.query.filter_by(name="the_vendor").first().id)
     assert response.status_code == 200
     assert len(response.json) == 1
-    assert response.json[0] == {"human_name": "The Vendor", "name": "the_vendor", "vendor_id": vendor_id}
+    assert response.json[0] == {
+        "human_name": "The Vendor",
+        "name": "the_vendor",
+        "vendor_id": vendor_id,
+    }
 
 
 def test_get_vendor_not_found(client, create_user):

--- a/tests/api/test_vendors.py
+++ b/tests/api/test_vendors.py
@@ -1,3 +1,5 @@
+from opencve.models.vendors import Vendor
+
 def test_list_vendors_authentication(client, create_user):
     create_user("opencve")
     response = client.get("/api/vendors")
@@ -16,9 +18,10 @@ def test_list_vendors(client, create_user, create_vendor):
 
     create_vendor("the_vendor", "the_product")
     response = client.login("opencve").get("/api/vendors")
+    vendor_id = str(Vendor.query.filter_by(name="the_vendor").first().id)
     assert response.status_code == 200
     assert len(response.json) == 1
-    assert response.json[0] == {"human_name": "The Vendor", "name": "the_vendor"}
+    assert response.json[0] == {"human_name": "The Vendor", "name": "the_vendor", "vendor_id": vendor_id}
 
 
 def test_get_vendor_not_found(client, create_user):
@@ -32,12 +35,13 @@ def test_get_vendor(client, create_user, create_vendor):
     create_user("opencve")
     create_vendor("vendor1", "product1")
     create_vendor("vendor1", "product2")
-
+    vendor_id = str(Vendor.query.filter_by(name="vendor1").first().id)
     response = client.login("opencve").get("/api/vendors/vendor1")
     assert response.status_code == 200
     assert response.json == {
         "human_name": "Vendor1",
         "name": "vendor1",
+        "vendor_id": vendor_id,
         "products": ["product1", "product2"],
     }
 


### PR DESCRIPTION
Per https://github.com/opencve/opencve/issues/240 this adds the ability to programmatically add vendors to a user.

I used vendor_ids because that seemed to be the convention with the subscription controller, this meant that vendor ids should be returned on vendor search.

Now a user can programmatically subscribe to vendors. This isn't a bulk operation, but it is still a reasonable way to subscribe via API. 