### PR TITLE
Fixes #432

### DIFF
--- a/docker/conf/.env.example
+++ b/docker/conf/.env.example
@@ -17,8 +17,8 @@ _AIRFLOW_WWW_USER_PASSWORD=airflow
 
 # Airflow configuration vars
 AIRFLOW__CORE__EXECUTOR=CeleryExecutor
-AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://opencve:opencve@postgres:5432/opencve
-AIRFLOW__CELERY__RESULT_BACKEND=db+postgresql://opencve:opencve@postgres:5432/opencve
+AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/opencve
+AIRFLOW__CELERY__RESULT_BACKEND=db+postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/opencve
 AIRFLOW__CELERY__BROKER_URL=redis://:@redis/1
 AIRFLOW__CORE__FERNET_KEY='ywvTuNQw6bW-UlEyS0ykTqiz9on1cyMlHT7e1Ddo060='
 AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION='true'


### PR DESCRIPTION
This makes use of the values set for variables `POSTGRES_USER` and `POSTGRES_PASSWORD` later in the `.env` file to make the docs work without additional steps.