### PR TITLE
fix: added overwriting template for nginx default.conf (#439)

### DIFF
--- a/docker/conf/default.conf.template.example
+++ b/docker/conf/default.conf.template.example
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -112,6 +112,7 @@ services:
        - "${OPENCVE_PORT:-80}:80"
     volumes:
       - ./conf/opencve.conf.template:/etc/nginx/templates/opencve.conf.template:ro
+      - ./conf/default.conf.template:/etc/nginx/templates/default.conf.template:ro
       - staticfiles:/var/www/opencve/static/:ro
     restart: on-failure
 

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -19,6 +19,7 @@ add-config-files() {
 
     echo "--> Copying opencve.conf.template for Nginx"
     cp ./conf/opencve.conf.template.example ./conf/opencve.conf.template
+    cp ./conf/default.conf.template.example ./conf/default.conf.template
 
     echo ""
     echo "/!\ Don't forget to update the .env and settings.py files with your inputs before starting the docker compose stack:"


### PR DESCRIPTION
This is a suggestion to overwrite `/etc/nginx/conf.d/default.conf`.
fixes #439 

# diagnostic for #439
- enter docker nginx with `docker exec -it nginx /bin/sh`
- run `nginx -T`
- observe following configuration

```
# configuration file /etc/nginx/conf.d/default.conf:
server {
    listen       80;
    listen  [::]:80;
    server_name  localhost;

    #access_log  /var/log/nginx/host.access.log  main;

    location / {
        root   /usr/share/nginx/html;
        index  index.html index.htm;
    }

    #error_page  404              /404.html;

    # redirect server error pages to the static page /50x.html
    #
    error_page   500 502 503 504  /50x.html;
    location = /50x.html {
        root   /usr/share/nginx/html;
    }

    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
    #
    #location ~ \.php$ {
    #    proxy_pass   http://127.0.0.1;
    #}

    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
    #
    #location ~ \.php$ {
    #    root           html;
    #    fastcgi_pass   127.0.0.1:9000;
    #    fastcgi_index  index.php;
    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
    #    include        fastcgi_params;
    #}

    # deny access to .htaccess files, if Apache's document root
    # concurs with nginx's one
    #
    #location ~ /\.ht {
    #    deny  all;
    #}
}
```

which matches localhost instead of the opencve webserver.

# suggested correction
replace `nginx` default server conf by an (essentially) empty file.