### PR TITLE
fix: disable the trailing slash in API

### DIFF
--- a/web/opencve/urls.py
+++ b/web/opencve/urls.py
@@ -16,7 +16,7 @@ from organizations.resources import OrganizationViewSet
 from projects.resources import ProjectCveViewSet, ProjectViewSet
 
 # API Router
-router = routers.SimpleRouter()
+router = routers.SimpleRouter(trailing_slash=False)
 router.register(r"cve", CveViewSet, basename="cve")
 
 router.register(r"weaknesses", WeaknessViewSet, basename="weakness")


### PR DESCRIPTION
From https://www.django-rest-framework.org/api-guide/routers/#simplerouter

Until this PR all endpoints without a trailing slash are redirected to the same URL, appending a "/". For example `GET https://app.opencve.io/api/cve` redirects to `https://app.opencve.io/api/cve/`.

Now `https://app.opencve.io/api/cve` works without redirection.