### PR TITLE
refactor: remove the dropcap css class in CVE details page

### DIFF
--- a/web/cves/templates/cves/cve_detail.html
+++ b/web/cves/templates/cves/cve_detail.html
@@ -16,7 +16,7 @@
         <div class="col-md-9">
             <div class="box box-primary">
                 <div class="box-body">
-                    <span class="dropcap">{{ cve.description|make_list|first }}</span>{{ cve.description|make_list|slice:'1:'|join:'' }}
+                    {{ cve.description }}
                 </div>
             </div>
 


### PR DESCRIPTION
Fix #442 

A lot of CVE descriptions start with non A-Z letters:

```
      cve_id      |                                                      left
------------------+----------------------------------------------------------------------------------------------------------------
 CVE-1999-0417    | 64 bit Solaris 7 procfs allows local users to perform a denial of service.
 CVE-1999-0572    | .reg files are associated with the Windows NT registry editor (regedit), making the registry suscept
 CVE-1999-1318    | /usr/5bin/su in SunOS 4.1.3 and earlier uses a search path that includes the current working directo
 CVE-1999-1336    | 3Com HiPer Access Router Card (HiperARC) 4.0 through 4.2.29 allows remote attackers to cause a denia
 CVE-1999-1383    | (1) bash before 1.14.7, and (2) tcsh 6.05 allow local users to gain privileges via directory names t
 CVE-1999-1480    | (1) acledit and (2) aclput in AIX 4.3 allow local users to create or modify files via a symlink atta
 CVE-1999-1501    | (1) ipxchk and (2) ipxlink in SGI OS2 IRIX 6.3 does not properly clear the IFS environmental variabl
 CVE-1999-1536    | .sbstart startup script in AcuShop Salesbuilder is world writable, which allows local users to gain
 CVE-1999-1554    | /usr/sbin/Mail on SGI IRIX 3.3 and 3.3.1 does not properly set the group ID to the group ID of the u
 CVE-1999-1587    | /usr/ucb/ps in Sun Microsystems Solaris 8 and 9, and certain earlier releases, allows local users to
 CVE-2000-1118    | 24Link 1.06 web server allows remote attackers to bypass access restrictions by prepending strings s
 CVE-2001-0102    | "Multiple Users" Control Panel in Mac OS 9 allows Normal users to gain Owner privileges by removing
 CVE-2001-0403    | /opt/JSparm/bin/perfmon program in Solaris allows local users to create arbitrary files as root via
...
```

So the result in the CVE detail view can be strange, for instance:

<img width="593" alt="image" src="https://github.com/user-attachments/assets/b3420b95-0fa1-4deb-9cb7-26908e2b575a">

This PR just removes the dropcap CSS class:

<img width="637" alt="image" src="https://github.com/user-attachments/assets/76f8ca78-e457-418d-b8f7-0d9296c9a5f8">

