### PR TITLE
chore: downgrade Celery Airflow provider due to a bug

### DIFF
--- a/scheduler/requirements.txt
+++ b/scheduler/requirements.txt
@@ -1,6 +1,6 @@
 apache-airflow-providers-postgres==6.0.0
 apache-airflow-providers-redis==4.0.0
-apache-airflow-providers-celery==3.9.0
+apache-airflow-providers-celery==3.8.5
 apache-airflow[statsd]==2.10.4
 apache-airflow[sentry]==2.10.4
 arrow==1.3.0


### PR DESCRIPTION
This PR downgrades the Celery Airflow provider to a previous version due to a bug identified in the current release. The issue affects task execution reliability:

```
...
  File "/.../.local/lib/python3.11/site-packages/airflow/providers/celery/cli/celery_command.py", line 234, in worker
    _run_command_with_daemon_option(
  File "/.../.local/lib/python3.11/site-packages/airflow/providers/celery/cli/celery_command.py", line 51, in _run_command_with_daemon_option
    raise AirflowOptionalProviderFeatureException(
airflow.exceptions.AirflowOptionalProviderFeatureException: Failed to import run_command_with_daemon_option. This feature is only available in Airflow versions >= 2.8.0
```

The downgrade is a temporary measure until the upstream bug is resolved (related issue can be found here: https://github.com/apache/airflow/issues/45364).
