### PR TITLE
Fix install.sh with positional argument

### DIFF
--- a/docker/install.sh
+++ b/docker/install.sh
@@ -280,6 +280,7 @@ while getopts ${OPTSTRING} opt; do
   esac
 done
 
+shift $((OPTIND -1))
 _COMMAND=$1
 
 case $_COMMAND in


### PR DESCRIPTION
Hello Team,

I propose this pull request to fix the install.sh script. Initially when you make install.sh -r master the command extracted was "-r".

![echo Release set to S_RELEASE](https://github.com/user-attachments/assets/72060e44-9d9b-4986-bf6e-7dfb855e3fdb)

With `shift $((OPTIND -1))` install.sh -r master prepare took the command well in account

![display-usage](https://github.com/user-attachments/assets/e14ba89c-8950-47f2-b829-f4d594bc37be)
