### PR TITLE
removing container names/named containers from docker-compose.yaml

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -21,7 +21,6 @@ x-airflow-common: &airflow-common
 services:
   airflow-webserver:
     <<: *airflow-common
-    container_name: airflow-webserver
     command: webserver
     ports:
       - "${AIRFLOW_WEBSERVER_PORT:-8080}:8080"
@@ -38,7 +37,6 @@ services:
 
   airflow-scheduler:
     <<: *airflow-common
-    container_name: airflow-scheduler
     command: scheduler
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8974/health"]
@@ -53,7 +51,6 @@ services:
 
   airflow-worker:
     <<: *airflow-common
-    container_name: airflow-worker
     command: celery worker
     healthcheck:
       test:
@@ -74,7 +71,6 @@ services:
 
   airflow-init:
     <<: *airflow-common
-    container_name: airflow-init
     entrypoint: /bin/bash
     # yamllint disable rule:line-length
     command:
@@ -88,7 +84,6 @@ services:
     user: "0:0"
 
   webserver:
-    container_name: webserver
     env_file:
       - .env
     build:
@@ -106,7 +101,6 @@ services:
     restart: on-failure
 
   nginx:
-    container_name: nginx
     image: nginx:bookworm
     ports:
        - "${OPENCVE_PORT:-80}:80"
@@ -117,7 +111,6 @@ services:
     restart: on-failure
 
   redis:
-    container_name: redis
     image: redis/redis-stack:latest
     healthcheck:
        test: ["CMD", "redis-cli", "ping"]
@@ -127,7 +120,6 @@ services:
     restart: on-failure
 
   postgres:
-    container_name: postgres
     image: postgres:${POSTGRES_VERSION:-15}
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-opencve}


### PR DESCRIPTION
# Introduction

I suggest that we remove container names/named containers from docker-compose.yaml and install.sh so that one can have multiple installations on the same docker host.

The only external dependency on having `container_name:` in the docker-compose.yaml file, is so that something (say, install.sh) can integrate with a specific running container. By just adding "compose" to the `docker` command in the install.sh script, we get rid of the hard coded dependency.

In some (say my) environment, I might want to use those names for other continers, and/or I would like to run multiple instances of the opencve application for whatever reason.

The fix:

* Remove the container_names from the docker compose file
* Fix the install.sh script so that it can interact with the continers properly
