### PR TITLE
Prevent error "database does not exist"

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -136,7 +136,7 @@ services:
       PGDATA: /var/lib/postgreqsql/data
     restart: on-failure
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "$POSTGRES_USER"]
+      test: ["CMD", "pg_isready", "-U", "$POSTGRES_USER", "-d", "opencve"]
       interval: 10s
       retries: 5
       start_period: 5s

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -260,7 +260,7 @@ create-superuser() {
     export $(grep -v '^#' .env | grep -E '^POSTGRES' | tr '\n' ' ')
 
     log "\n--------| Auto confirm the created user"
-    display-and-exec "confirming the created admin user" -q docker exec postgres psql -U "$POSTGRES_USER" -c "INSERT INTO account_emailaddress(email, verified, \"primary\", user_id) SELECT email, 1::bool, 1::bool, id FROM opencve_users ON CONFLICT (user_id, email) DO NOTHING;"
+    display-and-exec "confirming the created admin user" -q docker exec postgres psql -U "$POSTGRES_USER" -d opencve -c "INSERT INTO account_emailaddress(email, verified, \"primary\", user_id) SELECT email, 1::bool, 1::bool, id FROM opencve_users ON CONFLICT (user_id, email) DO NOTHING;"
 
     unset POSTGRES_USER
     unset POSTGRES_PASSWORD


### PR DESCRIPTION
Prevent error "database does not exist" if the username is different from the database name.
