### PR TITLE
feat: add CVE titles to change list, reports and dashboard views

### DIFF
--- a/web/changes/templates/changes/change_list.html
+++ b/web/changes/templates/changes/change_list.html
@@ -51,7 +51,7 @@
                             {% endif %}
                             <div class="timeline-item">
                                 <span class="time" title="{{ change.created_at|date:'d b Y, H:i' }}"><i class="fa fa-clock-o"></i> {{ change.created_at|date:"H:i" }}</span>
-                                <h3 class="timeline-header"><a href="{% url 'cve' cve_id=change.cve.cve_id %}">{{ change.cve.cve_id }}</a> <i>{% if change|is_new_cve %}is a new CVE{% else %}has changed{% endif %}</i> <a href="{% url 'change' cve_id=change.cve.cve_id id=change.id %}" class="btn-json-diff" data-toggle="tooltip" data-container="body" title="View the change details"><i class="fa fa-code"></i></a></h3>
+                                <h3 class="timeline-header"><a href="{% url 'cve' cve_id=change.cve.cve_id %}">{{ change.cve.cve_id }}</a> <strong>{{ change.cve.title|default:"" }}</strong> <i>{% if change|is_new_cve %}is a new CVE{% else %}has changed{% endif %}</i> <a href="{% url 'change' cve_id=change.cve.cve_id id=change.id %}" class="btn-json-diff" data-toggle="tooltip" data-container="body" title="View the change details"><i class="fa fa-code"></i></a></h3>
                                 <div class="timeline-body">
                                     <p>{{ change.cve.description }}</p>
                                     {% include 'changes/change_events.html' %}

--- a/web/cves/templates/cves/_cve_table.html
+++ b/web/cves/templates/cves/_cve_table.html
@@ -10,10 +10,10 @@
     </thead>
     {% for cve in cves %}
     <tr class="cve-header">
-        <td class="col-md-2"><a href="{% url 'cve' cve_id=cve.cve_id %}">{{cve.cve_id }}</a></td>
-        <td class="col-md-3">{{ cve.vendors|vendors_excerpt }}</td>
-        <td class="col-md-3">{{ cve.vendors|products_excerpt }}</td>
-        <td class="col-md-2 text-center">{{ cve.updated_at|date:"Y-m-d" }}</td>
+        <td class="col-md-6"><a href="{% url 'cve' cve_id=cve.cve_id %}">{{ cve.cve_id }}</a> <strong>{{ cve.title|default:"" }}</strong> </td>
+        <td class="col-md-2">{{ cve.vendors|vendors_excerpt }}</td>
+        <td class="col-md-2">{{ cve.vendors|products_excerpt }}</td>
+        <td class="col-md-1 text-center">{{ cve.updated_at|date:"Y-m-d" }}</td>
         {% if cve.cvssV3_1 %}
         <td class="col-md-1 text-center"><span class="label label-{{ cve.cvssV3_1.score|cvss_level }}">{{ cve.cvssV3_1.score }} {{ cve.cvssV3_1.score|cvss_human_score|title }}</span></td>
         {% else %}

--- a/web/projects/templates/projects/dashboard.html
+++ b/web/projects/templates/projects/dashboard.html
@@ -34,7 +34,7 @@
                         {% endif %}
                         <div class="timeline-item">
                             <span class="time" title="{{ change.created_at|date:'d b Y, H:i' }}"><i class="fa fa-clock-o"></i> {{ change.created_at|date:"H:i" }}</span>
-                            <h3 class="timeline-header"><a href="{% url 'cve' cve_id=change.cve.cve_id %}">{{ change.cve.cve_id }}</a> <i>{% if change|is_new_cve %}is a new CVE{% else %}has changed{% endif %}</i> <a href="{% url 'change' cve_id=change.cve.cve_id id=change.id %}" class="btn-json-diff" data-toggle="tooltip" data-container="body" title="View the change details"><i class="fa fa-code"></i></a></h3>
+                            <h3 class="timeline-header"><a href="{% url 'cve' cve_id=change.cve.cve_id %}">{{ change.cve.cve_id }}</a> <strong>{{ change.cve.title|default:"" }}</strong> <i>{% if change|is_new_cve %}is a new CVE{% else %}has changed{% endif %}</i> <a href="{% url 'change' cve_id=change.cve.cve_id id=change.id %}" class="btn-json-diff" data-toggle="tooltip" data-container="body" title="View the change details"><i class="fa fa-code"></i></a></h3>
                             <div class="timeline-body">
                                 <p class="timeline-cve-summary">{{ change.cve.description }}</p>
                                 {% include 'changes/change_events.html' %}

--- a/web/projects/templates/projects/report.html
+++ b/web/projects/templates/projects/report.html
@@ -35,6 +35,7 @@
                                 <h4>
                                     {{ change.cve.cve_id }}
                                     <small><a href="{% url 'cve' cve_id=change.cve.cve_id%}" target="_blank"><i class="fa fa-external-link"></i></a></small>
+                                    {{ change.cve.title|default:"" }}
                                 </h4>
                                 <p>{{ change.cve.description }}</p>
                             </div>


### PR DESCRIPTION
As suggested in https://github.com/opencve/opencve/issues/544, add titles to the dashboard and table view of CVE's.
This way the short summary is also available and context is given for the CVE. 

Seeing the title of a CVE in a table or dashboard provides quick context and makes it easier to understand the vulnerability at a glance. It helps with faster triage, prioritization, and decision-making. Without titles, you would need read the entire description, or go to the CVE page to get the context.