### PR TITLE
feat: Add 2FA option for users

### DIFF
--- a/web/opencve/conf/base.py
+++ b/web/opencve/conf/base.py
@@ -34,6 +34,7 @@ INSTALLED_APPS = [
     "django_prometheus",
     "allauth",
     "allauth.account",
+    "allauth.mfa",
     "allauth.socialaccount",
     "auditlog",
     "crispy_forms",
@@ -175,11 +176,11 @@ LOGIN_URL = "account_login"
 # User settings
 AUTH_USER_MODEL = "users.User"
 ACCOUNT_CHANGE_EMAIL = True
-ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_SIGNUP_FIELDS = ["email*", "username*", "password1*", "password2*"]
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_EMAIL_SUBJECT_PREFIX = "[OpenCVE] "
 ACCOUNT_LOGOUT_REDIRECT_URL = "account_login"
-ACCOUNT_AUTHENTICATION_METHOD = "username_email"
+ACCOUNT_LOGIN_METHODS = {"username", "email"}
 ACCOUNT_FORMS = {
     "login": "users.forms.LoginForm",
     "signup": "users.forms.RegisterForm",

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -6,8 +6,8 @@ django-environ==0.11.2
 django-extensions==3.2.3
 django-debug-toolbar==4.4.6
 django-hijack==3.7.1
-django-allauth==65.3.1
-django-allauth[socialaccount,openid]==65.3.1
+django-allauth==65.9.0
+django-allauth[socialaccount,openid, mfa]==65.9.0
 django-prometheus==2.3.1
 django-auditlog==3.0.0
 djangorestframework==3.15.2

--- a/web/templates/account/reauthenticate.html
+++ b/web/templates/account/reauthenticate.html
@@ -1,0 +1,19 @@
+
+{% extends 'users/base.html' %}
+
+{% load crispy_forms_tags %}
+
+{% block title %}Confirm Access - {{ block.super }}{% endblock %}
+
+{% block header %}Please reauthenticate to safeguard your account.{% endblock %}
+
+{% block content%}
+<form action="#" method="POST" id="reauthForm">
+    {% csrf_token %}
+    {% crispy form %}
+    <button type="submit" onclick="document.getElementById('reauthForm').submit()" class="btn btn-primary pull-right btn-flat">Validate</button>
+</form>
+{% endblock %}
+
+{% block links %}
+{% endblock %}

--- a/web/templates/mfa/authenticate.html
+++ b/web/templates/mfa/authenticate.html
@@ -1,0 +1,15 @@
+{% extends 'users/base.html' %}
+
+{% load crispy_forms_tags %}
+
+{% block title %} 2FA - Validation{% endblock %}
+
+{% block header %}2FA - Validation{% endblock %}
+
+{% block content%}
+<form action="./" method="POST" id="2faForm">
+    {% csrf_token %}
+    {% crispy form %}
+    <button type="submit" onclick="document.getElementById('2faForm').submit()" class="btn btn-primary pull-right btn-flat">Validate</button>
+</form>
+{% endblock %}

--- a/web/templates/mfa/index.html
+++ b/web/templates/mfa/index.html
@@ -1,0 +1,58 @@
+{% extends 'users/settings/base_settings.html' %}
+{% load allauth %}
+{% load crispy_forms_tags %}
+
+{% block content_settings %}
+<div class="row">
+    <div class="col-lg-12 col-md-12 col-sm-12">
+        <!-- Configure 2FA configuration -->
+
+        <!-- Deactivate 2FA account-->
+        <div class="col-lg-12 col-md-12 col-sm-12">
+            {% if "totp" in MFA_SUPPORTED_TYPES %}
+                <h3>Two-Factor Authentication</h3>
+                {% if authenticators.totp %}
+                    <p>
+                        Authentication using an authenticator app is active.
+                    </p>
+                {% else %}
+                    <p>
+                        An authenticator app is not active.
+                    </p>
+                {% endif %}
+
+                {% url 'mfa_deactivate_totp' as deactivate_url %}
+                {% url 'mfa_activate_totp' as activate_url %}
+                {% if authenticators.totp %}
+                    <a href="{{ deactivate_url }}" class="btn btn-danger">Deactivate</a>
+                {% else %}
+                    <a href="{{ activate_url }}" class="btn btn-success">Activate</a>
+                {% endif %}
+            {% endif %}
+
+            {% if "recovery_codes" in MFA_SUPPORTED_TYPES %}
+                {% with total_count=authenticators.recovery_codes.generate_codes|length unused_count=authenticators.recovery_codes.get_unused_codes|length %}
+                    <h3>Recovery Codes</h3>
+                    {% if authenticators.recovery_codes %}
+                        <p>There is {{ unused_count }} out of {{ total_count }} recovery codes available</p>
+                    {% else %}
+                        <p>No recovery codes set up.</p>
+                    {% endif %}
+
+                    {% if is_mfa_enabled %}
+                        {% if authenticators.recovery_codes %}
+                            {% if unused_count > 0 %}
+                                {% url 'mfa_view_recovery_codes' as view_url %}
+                                <a href="{{ view_url }}" class="btn btn-primary">View</a>&nbsp;
+                            {% endif %}
+                        {% endif %}
+
+                        {% url 'mfa_generate_recovery_codes' as generate_url %}
+                        <a href="{{ generate_url }}" class="btn btn-danger">Generate</a>
+                    {% endif %}
+                {% endwith %}
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/web/templates/mfa/recovery_codes/generate.html
+++ b/web/templates/mfa/recovery_codes/generate.html
@@ -1,0 +1,19 @@
+{% extends 'users/settings/base_settings.html' %}
+{% load crispy_forms_tags %}
+
+{% block content_settings %}
+<div class="row">
+    <div class="col-lg-12 col-md-12 col-sm-12">
+        <!-- Generate new recovery codes -->
+        <h3>Recovery Codes</h3>
+        <div class="callout callout-error">
+            <p>You are about to generate a new set of recovery codes for your account. This action will invalidate your existing codes. Are you sure?</p>
+        </div>
+        {% url 'mfa_generate_recovery_codes' as generate_url %}
+        <form method="post" action="{{ generate_url }}">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-danger">Regenerate recovery codes</button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/web/templates/mfa/recovery_codes/index.html
+++ b/web/templates/mfa/recovery_codes/index.html
@@ -1,0 +1,20 @@
+{% extends 'users/settings/base_settings.html' %}
+{% load crispy_forms_tags %}
+
+{% block content_settings %}
+<div class="row">
+    <div class="col-lg-12 col-md-12 col-sm-12">
+        <!-- Get recovery codes -->
+        <h3>Recovery Codes</h3>
+        <p>There is {{ unused_codes|length }} out of {{ total_count }} recovery codes available</p>
+        <ul>
+            {% for code in unused_codes %}
+                <li>{{ code }}</li>
+            {% endfor %}
+        </ul>
+
+        {% if unused_codes %}
+            {% url 'mfa_download_recovery_codes' as download_url %}
+            <a href="{{ download_url }}" class="btn btn-primary pull-right">Download codes</a>
+        {% endif %}
+{% endblock %}

--- a/web/templates/mfa/totp/activate_form.html
+++ b/web/templates/mfa/totp/activate_form.html
@@ -1,0 +1,24 @@
+{% extends 'users/settings/base_settings.html' %}
+{% load crispy_forms_tags %}
+
+{% block content_settings %}
+<div class="row">
+    <div class="col-lg-12 col-md-12 col-sm-12">
+        <!-- Configure 2FA -->
+        <h3>Activate Authenticator App</h3>
+        <img src="{{ totp_svg_data_uri }}"/>
+        <p>
+            <label for="authenticator_secret">Authenticator secret</label>
+            <input disabled="" id="authenticator_secret" value="{{ form.secret }}" type="text">
+            <span>You can store this secret and use it to reinstall your authenticator app at a later time.</span>
+        </p>
+
+        {% url 'mfa_activate_totp' as activate_url %}
+        <form method="post" action="{{ activate_url }}" id="activate2faForm">
+            {% csrf_token %}
+            {% crispy form %}
+            <button type="submit" onclick="document.getElementById('activate2faForm').submit()" class="btn btn-primary pull-right">Activate</button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/web/templates/mfa/totp/deactivate_form.html
+++ b/web/templates/mfa/totp/deactivate_form.html
@@ -1,0 +1,21 @@
+{% extends 'users/settings/base_settings.html' %}
+{% load crispy_forms_tags %}
+
+{% block content_settings %}
+<div class="row">
+    <div class="col-lg-12 col-md-12 col-sm-12">
+        <!-- Deactivate 2FA account-->
+        <div class="col-lg-12 col-md-12 col-sm-12">
+            <h3>Two-Factor Authentication</h3>
+            <div class="callout callout-error">
+                <p>This action can not be undone, you will need to configure 2FA again to being protected.</p>
+            </div>
+            {% url 'mfa_deactivate_totp' as deactivate_url %}
+            <form method="post" action="{{ deactivate_url }}">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-danger">Delete 2FA</button>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/web/users/templates/users/settings/base_settings.html
+++ b/web/users/templates/users/settings/base_settings.html
@@ -35,6 +35,9 @@
                     <li class="{% is_active_link 'settings_password' %}">
                         <a href="{% url 'settings_password' %}">Password</a>
                     </li>
+                    <li class="{% is_active_link 'mfa_index' 'mfa_deactivate_totp' 'mfa_activate_totp' 'mfa_view_recovery_codes' 'mfa_generate_recovery_codes' %}">
+                        <a href="{% url 'mfa_index' %}">2FA</a>
+                    </li>
                     <li class="{% is_active_link 'settings_social' %}">
                         <a href="{% url 'settings_social' %}">Social Auth</a>
                     </li>


### PR DESCRIPTION
This PR introduces support for optional OTP-based two-factor authentication using TOTP apps (e.g. Google Authenticator). 

In the default configuration 2FA is enabled but not enforced, it means that each user has the capability to strengthen their account with a 2FA but it's not mandatory.

### A new “2FA” tab under Account Settings
<img width="872" height="480" alt="Profile" src="https://github.com/user-attachments/assets/f2a16ea8-04d5-4177-9646-166a0adabcef" />

### QR code generation for binding OTP apps
<img width="866" height="515" alt="Tags" src="https://github.com/user-attachments/assets/78e0f42f-2ed0-409f-a317-cde7f9e8bf0c" />

### Backup codes generation and display
<img width="871" height="618" alt="Profile" src="https://github.com/user-attachments/assets/7095ef6a-8545-4b4a-b6e2-60ab7c84b3de" />

### After password validation, if 2FA is enabled, prompt for OTP

<img width="520" height="438" alt="C OpenCVE" src="https://github.com/user-attachments/assets/5c079b82-7f0e-4a77-98b9-722603c63676" />

### It will ask for password confirmation is session is not fresh for sensitive action such as remove 2FA or regenerate backup codes.

<img width="566" height="478" alt="1 Confirm Access - OpenCVE" src="https://github.com/user-attachments/assets/6e1454ea-d779-4f4b-aacc-3e331b78d8a5" />

### The 2FA could be removed by the user.
<img width="849" height="237" alt="Two-Factor Authentication" src="https://github.com/user-attachments/assets/3240d914-892b-41d7-a4fb-90640f8b33c1" />



