### PR TITLE
fix: issue [B324:hashlib] use of weak MD5 hash for security

### DIFF
--- a/web/cves/templatetags/opencve_extras.py
+++ b/web/cves/templatetags/opencve_extras.py
@@ -108,7 +108,7 @@ def is_top_vendor_or_product(name):
 @register.filter
 def gravatar_url(email, size=40):
     return "https://www.gravatar.com/avatar/{}?{}".format(
-        hashlib.md5(email.lower().encode("utf-8")).hexdigest(),
+        hashlib.md5(email.lower().encode("utf-8"), usedforsecurity=False).hexdigest(),
         urlencode({"s": str(size)}),
     )
 


### PR DESCRIPTION
MD5 hash is now explicitly marked as non-security (used only for gravatar email hashing). Fix bandit's B324 issue.
See https://bandit.readthedocs.io/en/latest/plugins/b324_hashlib.html