### PR TITLE
Add LDAP/LDAPS authentication support

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,7 +7,7 @@ ARG OPENCVE_REPOSITORY="https://github.com/opencve/opencve.git"
 ARG OPENCVE_VERSION="master"
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
-    git \
+    git gcc libldap2-dev libsasl2-dev libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -33,7 +33,7 @@ LABEL maintainer="dev@opencve.io"
 LABEL url="${OPENCVE_REPOSITORY}"
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y\
-    git \
+    git libldap2-dev libsasl2-dev libssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/web/opencve/conf/.env.example
+++ b/web/opencve/conf/.env.example
@@ -17,3 +17,7 @@ OPENCVE_V1_DATABASE=postgresql://opencve:opencve@postgres:5432/opencve_v1
 
 # Base URL
 OPENCVE_WEB_BASE_URL=https://app.opencve.io
+
+# LDAP
+LDAP_CA_CERT_PATH='/etc/ssl/certs/ca-certitifcates.crt'
+LDAP_VERIFY_CERT='true'

--- a/web/opencve/conf/base.py
+++ b/web/opencve/conf/base.py
@@ -7,6 +7,9 @@ import environ
 
 from pathlib import Path
 
+import ldap
+from django_auth_ldap.config import LDAPSearch, GroupOfNamesType, ActiveDirectoryGroupType
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
@@ -95,6 +98,7 @@ TEMPLATES = [
 WSGI_APPLICATION = "opencve.wsgi.application"
 
 AUTHENTICATION_BACKENDS = [
+    "django_auth_ldap.backend.LDAPBackend",
     "django.contrib.auth.backends.ModelBackend",
     "allauth.account.auth_backends.AuthenticationBackend",
 ]
@@ -147,6 +151,67 @@ PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.ScryptPasswordHasher",
     "django.contrib.auth.hashers.BCryptPasswordHasher",
 ]
+
+# LDAP
+
+# Server URL
+AUTH_LDAP_SERVER_URI = "ldaps://dc01.acme.org:636"
+
+# Service account
+AUTH_LDAP_BIND_DN = "CN=svc-opencve,OU=ServiceAccounts,DC=acme,DC=org"
+AUTH_LDAP_BIND_PASSWORD = "my.best.password"
+
+# Search scope
+AUTH_LDAP_USER_SEARCH = LDAPSearch(
+    "OU=Users,DC=acme,DC=org",
+    ldap.SCOPE_SUBTREE,
+    "(sAMAccountName=%(user)s)",
+)
+
+# Mapping LDAP -> Django User
+AUTH_LDAP_USER_ATTR_MAP = {
+    "first_name": "givenName",
+    "last_name": "sn",
+    "email": "mail",
+}
+
+# Group search scope
+AUTH_LDAP_GROUP_SEARCH = LDAPSearch (
+    "OU=Applications,OU=Groups,DC=acme,DC=org",
+    ldap.SCOPE_SUBTREE,
+    "(objectClass=group)",
+)
+AUTH_LDAP_GROUP_TYPE = ActiveDirectoryGroupType()
+
+# Access group
+AUTH_LDAP_REQUIRE_GROUP = "CN=OPENCVE,OU=Applications,OU=Groups,DC=acme,DC=org"
+
+# Mapping AD -> Organization
+LDAP_GROUP_ORG_MAPPING = {
+    "CN=OPENCVE,OU=Applications,OU=Groups,DC=acme,DC=org": {
+        "org": "MyOrganization",
+        "role": "member",
+    },
+}
+
+# Synchronize groups
+AUTH_LDAP_MIRROR_GROUPS = True
+
+# LDAPS certificates
+AUTH_LDAP_CONNECTION_OPTIONS = {
+    ldap.OPT_X_TLS_CACERTFILE: env.str("LDAP_CA_CERT_PATH", default="/etc/ssl/certs/ca-certitifcates.crt"),
+    ldap.OPT_X_TLS_REQUIRE_CERT: ldap.OPT_X_TLS_DEMAND if env.str("LDAP_VERIFY_CERT", default="true") else ldap.OPT_X_TLS_ALLOW,
+    ldap.OPT_X_TLS_NEWCTX: 0,
+}
+
+# STARTTLS
+# AUTH_LDAP_START_TLS = True
+
+# Create Django user at the first connexion
+AUTH_LDAP_ALWAYS_UPDATE_USER = True
+
+# Group caching (seconds) to avoid too many LDAP requests
+AUTH_LDAP_CACHE_TIMEOUT = 3600
 
 # Internationalization
 LANGUAGE_CODE = "en-us"

--- a/web/users/signals.py
+++ b/web/users/signals.py
@@ -1,6 +1,43 @@
 from allauth.account.signals import email_confirmed
 from django.dispatch import receiver
-from organizations.models import Membership
+from django.conf import settings
+from django.utils import timezone
+from organizations.models import Membership, Organization
+
+try:
+    from django_auth_ldap.backend import populate_user
+
+    @receiver(populate_user)
+    def sync_ldap_groups_to_orgs(sender, user, ldap_user, **kwargs):
+        """
+        Synchronise les groupes AD vers les organisations OpenCVE après chaque auth LDAP.
+        """
+        mapping = getattr(settings, "LDAP_GROUP_ORG_MAPPING", {})
+        if not mapping:
+            return
+
+        user_group_dns = set(ldap_user.group_dns)
+
+        for group_dn, config in mapping.items():
+            if group_dn not in user_group_dns:
+                continue
+
+            org, _ = Organization.objects.get_or_create(name=config["org"])
+            membership, created = Membership.objects.get_or_create(
+                user=user,
+                organization=org,
+                defaults={
+                    "role": config["role"],
+                    "date_invited": timezone.now(),
+                    "date_joined": timezone.now(),
+                },
+            )
+            if not created and membership.role != config["role"]:
+                membership.role = config["role"]
+                membership.save(update_fields=["role"])
+
+except ImportError:
+    pass
 
 
 @receiver(email_confirmed)


### PR DESCRIPTION
Adds LDAP and LDAPS authentication to OpenCVE via django-auth-ldap. Includes automatic organization membership assignment based on AD group membership, configured through a group-to-organization mapping in settings. TLS certificate path and verification mode are configurable via environment variables. The Dockerfile has been updated to include the required system libraries and Python package.