### PR TITLE
fix: print notification email footer once in plain-text templates

### DIFF
--- a/scheduler/dags/templates/email_notification.txt
+++ b/scheduler/dags/templates/email_notification.txt
@@ -9,6 +9,7 @@ This email has been sent from the {{ notification }} notification of the {{ orga
 Changes: {{ vulnerability.changes|join(', ') }}
 Subscriptions: {{ vulnerability.subscriptions|join(', ') }}
 {% endfor %}{% endif %}
+{% endfor %}
 {% if created_by_email %}
 This notification was created by {{ created_by_email }}
 {% endif %}
@@ -16,4 +17,4 @@ This notification was created by {{ created_by_email }}
 Unsubscribe from this notification: {{ unsubscribe_url }}
 {% endif %}
 Manage notification settings: {{ notification_url }}
-{% endfor %}&copy; {{ year }} OpenCVE, All rights reserved
+&copy; {{ year }} OpenCVE, All rights reserved

--- a/scheduler/tests/test_notifiers.py
+++ b/scheduler/tests/test_notifiers.py
@@ -325,6 +325,9 @@ def test_generate_email_previews(tests_path, tmp_path_factory):
     txt_template = env.get_template("email_notification.txt")
     txt_content = txt_template.render(context)
 
+    assert txt_content.count("Manage notification settings:") == 1
+    assert txt_content.count("&copy;") == 1
+
     # Save previews
     previews_dir = pathlib.Path(__file__).parent / "previews"
     previews_dir.mkdir(exist_ok=True)
@@ -400,6 +403,17 @@ def test_email_notifier_template_context_created_by_and_unsubscribe_url(
     assert context["unsubscribe_url"] == (
         "https://opencve.example.com/notifications/unsubscribe/my-unsubscribe-token"
     )
+
+    env = Environment(
+        loader=FileSystemLoader(
+            pathlib.Path(__file__).parent.parent / "dags/templates"
+        ),
+        autoescape=select_autoescape(),
+    )
+    txt_content = env.get_template("email_notification.txt").render(context)
+    assert txt_content.count("Manage notification settings:") == 1
+    assert txt_content.count("Unsubscribe from this notification:") == 1
+    assert "creator@example.com" in txt_content
 
 
 # Tests for BaseNotifier utility methods

--- a/web/projects/templates/projects/emails/notification_try.txt
+++ b/web/projects/templates/projects/emails/notification_try.txt
@@ -9,6 +9,7 @@ This email has been sent from the {{ notification }} notification of the {{ orga
 Changes: {{ vulnerability.changes|join:", " }}
 Subscriptions: {{ vulnerability.subscriptions|join:", " }}
 {% endfor %}{% endif %}
+{% endfor %}
 {% if created_by_email %}
 This notification was created by {{ created_by_email }}
 {% endif %}
@@ -16,4 +17,4 @@ This notification was created by {{ created_by_email }}
 Unsubscribe from this notification: {{ unsubscribe_url }}
 {% endif %}
 Manage notification settings: {{ notification_url }}
-{% endfor %}&copy; {{ year }} OpenCVE, All rights reserved
+&copy; {{ year }} OpenCVE, All rights reserved


### PR DESCRIPTION
Fix #755 