### PR TITLE
fix: repeated query params are kept when building pagination URLs

### DIFF
--- a/web/cves/templatetags/opencve_extras.py
+++ b/web/cves/templatetags/opencve_extras.py
@@ -307,16 +307,12 @@ def metric_class_from_ssvc(metric, value):
 
 @register.simple_tag(takes_context=True)
 def query_params_url(context, *args):
-    query_params = dict(context["request"].GET)
-    for key, value in query_params.items():
-        if isinstance(value, list):
-            query_params[key] = value[0]
+    query_params = context["request"].GET.copy()
 
-    # Update query values with new ones provided in the tag
-    grouped_params = {args[i]: args[i + 1] for i in range(0, len(args), 2)}
-    query_params.update(grouped_params)
+    for i in range(0, len(args), 2):
+        query_params[args[i]] = args[i + 1]
 
-    return urlencode(query_params)
+    return query_params.urlencode()
 
 
 @register.filter

--- a/web/tests/cves/test_templatetags.py
+++ b/web/tests/cves/test_templatetags.py
@@ -1,3 +1,5 @@
+from django.http import HttpRequest, QueryDict
+
 from cves.templatetags.opencve_extras import (
     get_item,
     get_active_cvss_tab,
@@ -6,7 +8,36 @@ from cves.templatetags.opencve_extras import (
     advisory_source_display,
     tracker_status_badge_class,
     enrichment_scores_tooltip,
+    query_params_url,
 )
+
+
+def test_query_params_url_preserves_multiple_values():
+    """Repeated query params are kept when building pagination URLs."""
+    request = HttpRequest()
+    request.GET = QueryDict(
+        "assignee=&status=to_evaluate&status=analysis_in_progress&view=&query="
+    )
+    context = {"request": request}
+
+    result = query_params_url(context, "page", 2)
+
+    assert "status=to_evaluate" in result
+    assert "status=analysis_in_progress" in result
+    assert "page=2" in result
+
+
+def test_query_params_url_updates_page_while_keeping_filters():
+    """Single-value filters are kept when overriding the page query param."""
+    request = HttpRequest()
+    request.GET = QueryDict("vendor=debian&page=1")
+    context = {"request": request}
+
+    result = query_params_url(context, "page", 2)
+
+    assert "vendor=debian" in result
+    assert "page=2" in result
+    assert "page=1" not in result
 
 
 def test_get_item():


### PR DESCRIPTION
Fix #756 