### PR TITLE
feat: display CPE version ranges in the NVD configurations

### DIFF
--- a/web/cves/templates/cves/includes/vendors_products.html
+++ b/web/cves/templates/cves/includes/vendors_products.html
@@ -119,6 +119,7 @@
                                 <td class="col-md-1 rowspaned" rowspan="{{ node.cpeMatch|length }}">OR</td>
                                 {% endif %}
                                 <td>{{ cpe.criteria }}</td>
+                                <td class="text-muted cpe-version-range">{{ cpe|cpe_version_range|default:"—" }}</td>
                             </tr>
                             {% endfor %}
                         </table>

--- a/web/cves/templatetags/opencve_extras.py
+++ b/web/cves/templatetags/opencve_extras.py
@@ -119,6 +119,30 @@ def enrichment_scores_tooltip(scores):
     return mark_safe("<br />".join(lines))
 
 
+CPE_VERSION_RANGE_LABELS = (
+    ("versionStartIncluding", "From (including)"),
+    ("versionStartExcluding", "From (excluding)"),
+    ("versionEndIncluding", "Up to (including)"),
+    ("versionEndExcluding", "Up to (excluding)"),
+)
+
+
+@register.filter
+def cpe_version_range(cpe):
+    """
+    Return the human readable version range of a NVD cpeMatch item
+    (ex: `From (including) 1.0 Up to (excluding) 2.0`).
+    """
+    if not isinstance(cpe, dict):
+        return ""
+
+    return " ".join(
+        f"{label} {cpe[field]}"
+        for field, label in CPE_VERSION_RANGE_LABELS
+        if cpe.get(field)
+    )
+
+
 @register.filter
 def is_top_vendor_or_product(name):
     """Return True if the vendor/product is in the static warning list (many CVEs)."""

--- a/web/tests/cves/test_templatetags.py
+++ b/web/tests/cves/test_templatetags.py
@@ -1,6 +1,7 @@
 from django.http import HttpRequest, QueryDict
 
 from cves.templatetags.opencve_extras import (
+    cpe_version_range,
     get_item,
     get_active_cvss_tab,
     get_cvss_score,
@@ -293,3 +294,42 @@ def test_tracker_status_badge_class(status, expected):
     Test tracker_status_badge_class function.
     """
     assert tracker_status_badge_class(status) == expected
+
+
+@pytest.mark.parametrize(
+    "cpe, expected",
+    [
+        # No version range
+        ({"criteria": "cpe:2.3:a:zabbix:zabbix:*:*:*:*:*:*:*:*"}, ""),
+        # Only a lower bound
+        ({"versionStartIncluding": "5.4.0"}, "From (including) 5.4.0"),
+        ({"versionStartExcluding": "5.4.0"}, "From (excluding) 5.4.0"),
+        # Only an upper bound
+        ({"versionEndIncluding": "5.4.14"}, "Up to (including) 5.4.14"),
+        ({"versionEndExcluding": "5.4.14"}, "Up to (excluding) 5.4.14"),
+        # Both bounds
+        (
+            {"versionStartIncluding": "5.4.0", "versionEndExcluding": "5.4.14"},
+            "From (including) 5.4.0 Up to (excluding) 5.4.14",
+        ),
+        (
+            {"versionStartExcluding": "5.4.0", "versionEndIncluding": "5.4.14"},
+            "From (excluding) 5.4.0 Up to (including) 5.4.14",
+        ),
+        # Empty values are ignored
+        (
+            {"versionStartIncluding": "", "versionEndIncluding": "5.4.14"},
+            "Up to (including) 5.4.14",
+        ),
+        # Unexpected types are ignored
+        ({}, ""),
+        (None, ""),
+        ("cpe:2.3:a:zabbix:zabbix:*:*:*:*:*:*:*:*", ""),
+    ],
+)
+def test_cpe_version_range(cpe, expected):
+    """
+    Test cpe_version_range function used to display the version ranges
+    of the NVD CPE configurations.
+    """
+    assert cpe_version_range(cpe) == expected

--- a/web/tests/cves/test_views.py
+++ b/web/tests/cves/test_views.py
@@ -1607,3 +1607,58 @@ def test_cves_export_csv_redirects_when_over_limit(create_cve, auth_client):
         messages_list[0].message
         == "Export limit exceeded: 1 CVEs match your query. Please refine your search to export 10,000 CVEs or fewer."
     )
+
+
+@patch("cves.models.Cve.nvd_json", new_callable=PropertyMock)
+@patch("cves.models.Cve.mitre_json", new_callable=PropertyMock)
+@patch("cves.models.Cve.redhat_json", new_callable=PropertyMock)
+@patch("cves.models.Cve.vulnrichment_json", new_callable=PropertyMock)
+@patch("cves.models.Cve.enrichment_json", new_callable=PropertyMock)
+@override_settings(ENABLE_ONBOARDING=False)
+def test_cve_detail_page_displays_cpe_version_ranges(
+    mock_enrichment,
+    mock_vulnrichment,
+    mock_redhat,
+    mock_mitre,
+    mock_nvd,
+    db,
+    create_cve,
+    client,
+):
+    """The CPE configurations display the version ranges of each CPE."""
+    mock_nvd.return_value = {
+        "configurations": [
+            {
+                "nodes": [
+                    {
+                        "operator": "OR",
+                        "cpeMatch": [
+                            {
+                                "criteria": "cpe:2.3:a:zabbix:zabbix:*:*:*:*:*:*:*:*",
+                                "versionStartIncluding": "5.4.0",
+                                "versionEndExcluding": "5.4.9",
+                            },
+                            {
+                                "criteria": "cpe:2.3:a:zabbix:zabbix:6.0.0:*:*:*:*:*:*:*",
+                            },
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+    mock_mitre.return_value = {}
+    mock_redhat.return_value = {}
+    mock_vulnrichment.return_value = {}
+    mock_enrichment.return_value = {}
+
+    create_cve("CVE-2024-31331")
+
+    response = client.get(reverse("cve", kwargs={"cve_id": "CVE-2024-31331"}))
+    soup = BeautifulSoup(response.content, features="html.parser")
+    ranges = [
+        cell.text.strip()
+        for cell in soup.find_all("td", {"class": "cpe-version-range"})
+    ]
+
+    assert ranges == ["From (including) 5.4.0 Up to (excluding) 5.4.9", "—"]


### PR DESCRIPTION
## Description

Closes #180.

The CPE Configurations tab on a CVE page rendered only `{{ cpe.criteria }}` and silently dropped every version boundary that came with the configuration. Two NVD configurations covering different version ranges of the same product therefore rendered identically, and there was no way to tell from the UI which versions a given configuration actually applied to — which is the whole point of the "From" / "Up to" information the issue asks for.

This adds a `cpe_version_range` template filter that formats the four NVD boundary fields (`versionStartIncluding`, `versionStartExcluding`, `versionEndIncluding`, `versionEndExcluding`) into a readable range, and renders it as a new column in the configurations table.

## Changes

- `web/cves/templatetags/opencve_extras.py` — new `cpe_version_range` filter plus a `CPE_VERSION_RANGE_LABELS` mapping
- `web/cves/templates/cves/includes/vendors_products.html` — one new `<td>`
- `web/tests/cves/test_templatetags.py` — 11 parametrized unit cases
- `web/tests/cves/test_views.py` — an integration test asserting the ranges appear on the rendered CVE detail page

No database migration, no new dependency, no scheduler or KB involvement.

## Security note

The filter deliberately does **not** use `mark_safe`. These values come from third-party NVD JSON and stay under Django's autoescaping. No existing check was weakened.

## Testing

Verified red first. With the fix stashed, the new assertion fails:

```
assert ranges == [...]
AssertionError: assert [] == ['From (inclu...) 5.4.9', '—']
1 failed in 0.94s
```

Green, and against a captured baseline so the delta is provable:

```
# baseline, before any edit
pytest tests/ -q                    1239 passed in 42.29s

# targeted
pytest tests/cves/test_templatetags.py::test_cpe_version_range \
       tests/cves/test_views.py::test_cve_detail_page_displays_cpe_version_ranges -v
                                    12 passed in 1.13s

# full suite after the change
python manage.py check              System check identified no issues (0 silenced).
pytest tests/ -q                    1251 passed in 44.44s      (1239 + 12 new)
```

Lint, using the repo's own pre-commit hooks:

```
pre-commit run --files <4 changed files>
  Fix End of Files.........Passed
  Trim Trailing Whitespace.Passed
  black....................Passed

black --check web/         258 files would be left unchanged
```

Ran against a throwaway PostgreSQL 18 instance, matching the service in `.github/workflows/tests.yml`.

Not run: the `tests-scheduler` CI job, which needs Redis plus a migrated web database. This change touches no scheduler file.

## Note on issue triage

While picking this up I confirmed **#533 is already fixed** — PR #537 ("fix: add Date header to sent messages") merged 2025-02-25 and `scheduler/dags/includes/utils.py:261` now reads `message["Date"] = formatdate()`. The issue is just stale-open and could be closed.

Two other things noticed in passing, neither touched here:

- `web/users/models.py:51` emits `SyntaxWarning: invalid escape sequence '\-'` on every `manage.py check` — `regex="^[a-zA-Z0-9\-_]+$"` wants to be a raw string. Harmless today, a `SyntaxError` in a future Python.
- #564 is still live: `docker/docker-compose.yaml:132` and `:141` both spell it `/var/lib/postgreqsql/data`. Because `PGDATA` and the mountpoint share the typo the data is safe, but the postgres image's declared volume spawns an extra anonymous volume alongside the named one.
