### PR TITLE
Fix project filter failing in API context with Bearer token

### DIFF
--- a/web/opencve/api/tokens.py
+++ b/web/opencve/api/tokens.py
@@ -45,3 +45,4 @@ def bind_organization_token(request, org_token):
     org_token.update_last_used()
     request.authenticated_organization = org_token.organization
     request.api_token = org_token
+    request.current_organization = org_token.organization

--- a/web/tests/api/v2/viewsets/test_catalog.py
+++ b/web/tests/api/v2/viewsets/test_catalog.py
@@ -138,6 +138,58 @@ def test_cve_list_with_invalid_q_filter(client, read_token, create_cve):
 
 
 @pytest.mark.django_db
+def test_cve_list_with_project_filter(
+    client, api_context, read_token, create_project, create_cve
+):
+    """Filter CVE list by project using Bearer token only (no session cookies)."""
+    _user, organization, _create_token = api_context
+
+    # Create a project with specific vendor subscriptions
+    create_project(name="TestProject", organization=organization, vendors=["cisco"])
+
+    # Create CVEs with different vendors
+    create_cve("CVE-2021-44228")  # cisco vendor
+    create_cve("CVE-2022-22965")  # cisco vendor
+    create_cve("CVE-2021-34181")  # juniper vendor (not in project)
+
+    # Test project filter alone
+    response = client.get(
+        f"{cve_list_url()}?q=project:TestProject",
+        **bearer(read_token),
+    )
+
+    assert response.status_code == 200
+    cve_ids = [item["cve_id"] for item in response.json()["results"]]
+    # Should only return CVEs matching the project's vendor subscriptions
+    assert set(cve_ids) == {"CVE-2021-44228", "CVE-2022-22965"}
+
+
+@pytest.mark.django_db
+def test_cve_list_with_project_and_date_filter(
+    client, api_context, read_token, create_project, create_cve
+):
+    """Filter CVE list by project combined with date filter using Bearer token only."""
+    _user, organization, _create_token = api_context
+
+    # Create a project
+    create_project(name="TestProject", organization=organization, vendors=["cisco"])
+
+    # Create CVEs
+    create_cve("CVE-2021-44228")
+    create_cve("CVE-2022-22965")
+
+    # Test combined query: project AND date filter
+    response = client.get(
+        f"{cve_list_url()}?q=project:TestProject AND updated>=2020-01-01",
+        **bearer(read_token),
+    )
+
+    assert response.status_code == 200
+    # Should return CVEs that match both conditions
+    assert response.json()["count"] >= 0  # At least validates the query doesn't fail
+
+
+@pytest.mark.django_db
 @patch("cves.models.Cve.nvd_json", new_callable=PropertyMock)
 def test_cve_retrieve_with_nvd_cpe_configurations_include(
     mock_nvd_json, client, read_token, create_cve


### PR DESCRIPTION
## Summary

Fixes #776 

The `project:` filter in advanced search queries was failing when used via API with Bearer token authentication, returning "The project does not exist" error even though the project exists.

## Root Cause

The `ProjectFilter` relies on `request.current_organization`, which is:
- Set by `OrganizationMiddleware` in web requests ✅
- **Not** set by `bind_organization_token` in API requests ❌

This caused the filter to look for `Project.objects.get(name="X", organization=None)`, which always fails.

## Solution

Following @ncrocfer suggestion, added one line in `bind_organization_token()`:

```python
request.current_organization = org_token.organization
```

This aligns API context with web context, making all organization-scoped code paths work consistently.

## Testing

### Manual validation (Bearer token only, no session cookies)
- ✅ `GET /api/v2/cves?q=project:XXX` → 3177 CVEs
- ✅ `GET /api/v2/cves?q=project:XXXAND updated>=2026-08-24` → 3 CVEs  
- ✅ `GET /api/v2/cves?q=updated>=2026-08-24 AND project:XXX` → 3 CVEs
- ✅ GUI still works (no regression)

### Automated tests added
- `test_cve_list_with_project_filter` - Tests project filter alone
- `test_cve_list_with_project_and_date_filter` - Tests combined query